### PR TITLE
feat: add --remote flag for git clone + periodic refresh

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,6 +6,13 @@
       "env": {
         "RUST_LOG": "skillet=debug"
       }
+    },
+    "skillet-remote": {
+      "command": "cargo",
+      "args": ["run", "--", "--remote", "https://github.com/joshrotenberg/grimoire.git", "--subdir", "test-registry"],
+      "env": {
+        "RUST_LOG": "skillet=debug"
+      }
     }
   }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,0 +1,65 @@
+//! Git operations for remote registry support.
+//!
+//! Shells out to the `git` CLI for clone, pull, and HEAD inspection.
+//! No `git2`/`gix` dependency -- keeps things simple.
+
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, bail};
+
+/// Clone a repository to the target directory (shallow by default).
+pub fn clone(url: &str, target: &Path) -> anyhow::Result<()> {
+    let status = Command::new("git")
+        .args(["clone", "--depth", "1", url])
+        .arg(target)
+        .status()
+        .context("Failed to run git clone")?;
+
+    if !status.success() {
+        bail!("git clone failed with status {status}");
+    }
+
+    Ok(())
+}
+
+/// Pull latest changes in an existing clone.
+pub fn pull(repo_path: &Path) -> anyhow::Result<()> {
+    let status = Command::new("git")
+        .args(["pull"])
+        .current_dir(repo_path)
+        .status()
+        .context("Failed to run git pull")?;
+
+    if !status.success() {
+        bail!("git pull failed with status {status}");
+    }
+
+    Ok(())
+}
+
+/// Get the current HEAD commit hash.
+pub fn head(repo_path: &Path) -> anyhow::Result<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repo_path)
+        .output()
+        .context("Failed to run git rev-parse HEAD")?;
+
+    if !output.status.success() {
+        bail!("git rev-parse HEAD failed with status {}", output.status);
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Clone if the target doesn't exist, otherwise pull.
+pub fn clone_or_pull(url: &str, target: &Path) -> anyhow::Result<()> {
+    if target.join(".git").exists() {
+        tracing::info!(path = %target.display(), "Pulling existing clone");
+        pull(target)
+    } else {
+        tracing::info!(url, path = %target.display(), "Cloning remote registry");
+        clone(url, target)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,15 @@
 //! An MCP-native skill registry for AI agents. Serves skills from a local
 //! registry directory (git checkout) via tools and resource templates.
 
+mod git;
 mod index;
 mod resources;
 mod state;
 mod tools;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
 
 use clap::Parser;
 use tower_mcp::{McpRouter, StdioTransport};
@@ -19,13 +22,83 @@ use crate::state::AppState;
 #[command(name = "skillet")]
 #[command(about = "MCP-native skill registry for AI agents")]
 struct Args {
-    /// Path to the registry directory (contains owner/skill-name/ directories)
-    #[arg(long, default_value = "test-registry")]
-    registry: PathBuf,
+    /// Path to a local registry directory (contains owner/skill-name/ directories)
+    #[arg(long, group = "source")]
+    registry: Option<PathBuf>,
+
+    /// Git URL to clone/pull the registry from
+    #[arg(long, group = "source")]
+    remote: Option<String>,
+
+    /// How often to pull from the remote (e.g. "5m", "1h", "0" to disable).
+    /// Only used with --remote.
+    #[arg(long, default_value = "5m")]
+    refresh_interval: String,
+
+    /// Directory to clone remote registries into
+    #[arg(long)]
+    cache_dir: Option<PathBuf>,
+
+    /// Subdirectory within the registry (local or remote) that contains the skills
+    #[arg(long)]
+    subdir: Option<PathBuf>,
 
     /// Log level
     #[arg(short, long, default_value = "info")]
     log_level: String,
+}
+
+/// Parse a human-friendly duration string like "5m", "1h", "30s", or "0".
+fn parse_duration(s: &str) -> anyhow::Result<Duration> {
+    let s = s.trim();
+    if s == "0" {
+        return Ok(Duration::ZERO);
+    }
+
+    let (num, suffix) = s.split_at(s.find(|c: char| !c.is_ascii_digit()).unwrap_or(s.len()));
+    let num: u64 = num
+        .parse()
+        .map_err(|_| anyhow::anyhow!("Invalid duration number: {s}"))?;
+
+    let secs = match suffix {
+        "s" | "" => num,
+        "m" => num * 60,
+        "h" => num * 3600,
+        _ => anyhow::bail!("Unknown duration suffix: {suffix} (use s, m, or h)"),
+    };
+
+    Ok(Duration::from_secs(secs))
+}
+
+/// Derive a cache directory from the remote URL.
+///
+/// Turns `https://github.com/owner/repo.git` into `<base>/owner_repo`.
+fn cache_dir_for_url(base: &Path, url: &str) -> PathBuf {
+    let slug: String = url
+        .trim_end_matches(".git")
+        .rsplit('/')
+        .take(2)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<Vec<_>>()
+        .join("_");
+
+    let slug = if slug.is_empty() {
+        "default".to_string()
+    } else {
+        slug
+    };
+
+    base.join(slug)
+}
+
+fn default_cache_dir() -> PathBuf {
+    if let Ok(home) = std::env::var("HOME") {
+        PathBuf::from(home).join(".cache").join("skillet")
+    } else {
+        PathBuf::from("/tmp").join("skillet")
+    }
 }
 
 #[tokio::main]
@@ -42,11 +115,45 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .with_writer(std::io::stderr)
         .init();
 
-    tracing::info!(registry = %args.registry.display(), "Starting skillet server");
+    // Determine the registry path
+    let registry_path = match (&args.registry, &args.remote) {
+        (Some(path), None) => path.clone(),
+        (None, Some(url)) => {
+            let base = args.cache_dir.unwrap_or_else(default_cache_dir);
+            let target = cache_dir_for_url(&base, url);
+
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+
+            git::clone_or_pull(url, &target)?;
+            target
+        }
+        (None, None) => {
+            // Default to local test-registry for development
+            PathBuf::from("test-registry")
+        }
+        (Some(_), Some(_)) => unreachable!("clap group prevents this"),
+    };
+
+    let registry_path = match args.subdir {
+        Some(sub) => registry_path.join(sub),
+        None => registry_path,
+    };
+
+    tracing::info!(registry = %registry_path.display(), "Starting skillet server");
 
     // Load the skill index
-    let skill_index = index::load_index(&args.registry)?;
-    let state = AppState::new(args.registry, skill_index);
+    let skill_index = index::load_index(&registry_path)?;
+    let state = AppState::new(registry_path, skill_index);
+
+    // Spawn background refresh task if using a remote
+    if let Some(url) = args.remote {
+        let interval = parse_duration(&args.refresh_interval)?;
+        if interval > Duration::ZERO {
+            spawn_refresh_task(Arc::clone(&state), url, interval);
+        }
+    }
 
     // Build tools
     let search_skills = tools::search_skills::build(state.clone());
@@ -101,4 +208,110 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     StdioTransport::new(router).run().await?;
 
     Ok(())
+}
+
+/// Spawn a background task that periodically pulls from the remote and
+/// reloads the index if the HEAD commit changes.
+fn spawn_refresh_task(state: Arc<AppState>, url: String, interval: Duration) {
+    tracing::info!(
+        interval_secs = interval.as_secs(),
+        "Starting background refresh task"
+    );
+
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(interval).await;
+
+            let registry_path = state.registry_path.clone();
+
+            let result = tokio::task::spawn_blocking(move || -> anyhow::Result<Option<_>> {
+                let before = git::head(&registry_path)?;
+                git::pull(&registry_path)?;
+                let after = git::head(&registry_path)?;
+
+                if before == after {
+                    return Ok(None);
+                }
+
+                tracing::info!(
+                    before = %before,
+                    after = %after,
+                    "HEAD changed, reloading index"
+                );
+
+                let new_index = index::load_index(&registry_path)?;
+                Ok(Some(new_index))
+            })
+            .await;
+
+            match result {
+                Ok(Ok(Some(new_index))) => {
+                    let mut idx = state.index.write().await;
+                    *idx = new_index;
+                    tracing::info!(url = %url, "Index refreshed from remote");
+                }
+                Ok(Ok(None)) => {
+                    tracing::debug!(url = %url, "No changes from remote");
+                }
+                Ok(Err(e)) => {
+                    tracing::warn!(
+                        url = %url,
+                        error = %e,
+                        "Failed to refresh from remote, keeping current index"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        url = %url,
+                        error = %e,
+                        "Refresh task panicked, keeping current index"
+                    );
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_duration_seconds() {
+        assert_eq!(parse_duration("30s").unwrap(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_parse_duration_minutes() {
+        assert_eq!(parse_duration("5m").unwrap(), Duration::from_secs(300));
+    }
+
+    #[test]
+    fn test_parse_duration_hours() {
+        assert_eq!(parse_duration("1h").unwrap(), Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn test_parse_duration_zero() {
+        assert_eq!(parse_duration("0").unwrap(), Duration::ZERO);
+    }
+
+    #[test]
+    fn test_parse_duration_bare_number() {
+        assert_eq!(parse_duration("60").unwrap(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_cache_dir_for_url_github() {
+        let base = PathBuf::from("/tmp/skillet");
+        let dir = cache_dir_for_url(&base, "https://github.com/owner/repo.git");
+        assert_eq!(dir, PathBuf::from("/tmp/skillet/owner_repo"));
+    }
+
+    #[test]
+    fn test_cache_dir_for_url_no_git_suffix() {
+        let base = PathBuf::from("/tmp/skillet");
+        let dir = cache_dir_for_url(&base, "https://github.com/owner/repo");
+        assert_eq!(dir, PathBuf::from("/tmp/skillet/owner_repo"));
+    }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -12,7 +12,6 @@ pub struct AppState {
     /// In-memory skill index, refreshable
     pub index: RwLock<SkillIndex>,
     /// Path to the registry root (git checkout)
-    #[allow(dead_code)]
     pub registry_path: PathBuf,
 }
 


### PR DESCRIPTION
## Summary

- Add `--remote <url>` to clone a git registry on startup (mutually exclusive with `--registry`)
- Background refresh task pulls on `--refresh-interval` (default 5m), compares HEAD, and hot-swaps the index when changes are detected
- New `--subdir` flag for registries where skills live in a subdirectory
- New `--cache-dir` flag to control where clones land (default `~/.cache/skillet/`)
- Git operations isolated in `src/git.rs` (shells out to git CLI for now)
- Added `skillet-remote` MCP config for testing remote mode

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] All 8 tests pass (7 new + 1 existing)
- [x] Manual test: `skillet-remote` MCP server clones from GitHub and serves skills

Closes #1