### PR TITLE
feat: add registry config.toml and multi-version support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +271,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,13 +305,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -299,10 +341,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -396,6 +450,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +476,12 @@ checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "redox_syscall"
@@ -472,6 +542,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +584,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -593,6 +682,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml",
  "tower-mcp",
@@ -644,6 +734,19 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "tempfile"
+version = "3.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thiserror"
@@ -858,6 +961,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +983,58 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "windows-link"
@@ -971,6 +1132,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1"
+
+[dev-dependencies]
+tempfile = "3.26.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,9 +143,10 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
 
     tracing::info!(registry = %registry_path.display(), "Starting skillet server");
 
-    // Load the skill index
+    // Load registry config and skill index
+    let config = index::load_config(&registry_path)?;
     let skill_index = index::load_index(&registry_path)?;
-    let state = AppState::new(registry_path, skill_index);
+    let state = AppState::new(registry_path, skill_index, config);
 
     // Spawn background refresh task if using a remote
     if let Some(url) = args.remote {
@@ -168,7 +169,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
 
     // Assemble router
     let router = McpRouter::new()
-        .server_info("skillet", env!("CARGO_PKG_VERSION"))
+        .server_info(&state.config.registry.name, env!("CARGO_PKG_VERSION"))
         .instructions(
             "Skillet is a skill registry for AI agents. Use it to discover and \
              fetch skills relevant to your current task.\n\n\

--- a/src/resources/skill_content.rs
+++ b/src/resources/skill_content.rs
@@ -80,10 +80,26 @@ pub fn build_versioned(state: Arc<AppState>) -> ResourceTemplate {
                     .iter()
                     .find(|v| v.version == version)
                     .ok_or_else(|| {
+                        let available: Vec<&str> =
+                            entry.versions.iter().map(|v| v.version.as_str()).collect();
                         tower_mcp::Error::tool(format!(
-                            "Version '{version}' not found for '{owner}/{name}'"
+                            "Version '{version}' not found for '{owner}/{name}'. \
+                             Available versions: {}",
+                            available.join(", ")
                         ))
                     })?;
+
+                if !skill_version.has_content {
+                    let latest_ver = entry
+                        .latest()
+                        .map(|v| v.version.as_str())
+                        .unwrap_or("unknown");
+                    return Err(tower_mcp::Error::tool(format!(
+                        "Content for '{owner}/{name}' v{version} is not available. \
+                         Historical version content is stored in git history. \
+                         Use the latest version (v{latest_ver}) for full content.",
+                    )));
+                }
 
                 Ok(ReadResourceResult {
                     contents: vec![ResourceContent {

--- a/src/tools/list_skills_by_owner.rs
+++ b/src/tools/list_skills_by_owner.rs
@@ -50,9 +50,14 @@ pub fn build(state: Arc<AppState>) -> Tool {
                 let mut output =
                     format!("## Skills by {} ({} total)\n\n", input.owner, results.len());
                 for s in &results {
+                    let version_info = if s.version_count > 1 {
+                        format!("v{}, {} versions", s.version, s.version_count)
+                    } else {
+                        format!("v{}", s.version)
+                    };
                     output.push_str(&format!(
-                        "- **{}** (v{}) -- {}\n",
-                        s.name, s.version, s.description,
+                        "- **{}** ({}) -- {}\n",
+                        s.name, version_info, s.description,
                     ));
                 }
 

--- a/src/tools/search_skills.rs
+++ b/src/tools/search_skills.rs
@@ -116,9 +116,14 @@ pub fn build(state: Arc<AppState>) -> Tool {
 
                 let mut output = format!("Found {} skill(s):\n\n", results.len());
                 for s in &results {
+                    let version_info = if s.version_count > 1 {
+                        format!("v{}, {} versions", s.version, s.version_count)
+                    } else {
+                        format!("v{}", s.version)
+                    };
                     output.push_str(&format!(
-                        "## {}/{} (v{})\n{}\n",
-                        s.owner, s.name, s.version, s.description,
+                        "## {}/{} ({})\n{}\n",
+                        s.owner, s.name, version_info, s.description,
                     ));
                     if let Some(ref trigger) = s.trigger {
                         output.push_str(&format!("**When to use:** {trigger}\n"));

--- a/test-registry/acme/python-dev/versions.toml
+++ b/test-registry/acme/python-dev/versions.toml
@@ -1,0 +1,9 @@
+[[versions]]
+version = "2025.12.01"
+published = "2025-12-01T12:00:00Z"
+yanked = true
+
+[[versions]]
+version = "2026.01.15"
+published = "2026-01-15T12:00:00Z"
+yanked = false

--- a/test-registry/config.toml
+++ b/test-registry/config.toml
@@ -1,0 +1,3 @@
+[registry]
+name = "skillet"
+version = 1

--- a/test-registry/joshrotenberg/rust-dev/versions.toml
+++ b/test-registry/joshrotenberg/rust-dev/versions.toml
@@ -1,0 +1,14 @@
+[[versions]]
+version = "2026.01.01"
+published = "2026-01-01T12:00:00Z"
+yanked = false
+
+[[versions]]
+version = "2026.02.01"
+published = "2026-02-01T12:00:00Z"
+yanked = false
+
+[[versions]]
+version = "2026.02.24"
+published = "2026-02-24T12:00:00Z"
+yanked = false


### PR DESCRIPTION
## Summary

- Add `config.toml` loading from registry root with `RegistryConfig` types (`name`, `version`, `urls`, `auth`). Absent file uses defaults; malformed file fails loudly.
- Use registry name from config in `server_info` instead of hardcoded value, enabling alternative/private registries.
- Add multi-version skill support via `versions.toml` with historical version placeholders, yanked version handling, and enriched `SkillSummary` with published timestamps and available version lists.

Closes #2
Closes #3

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] All 17 tests pass (`cargo test --all-features`)
- [x] `test_load_config_from_test_registry`: loads existing config.toml
- [x] `test_load_config_default_when_absent`: returns defaults from dir without config.toml
- [x] `test_load_config_with_full_fields`: parses config.toml with all fields
- [x] `test_load_config_malformed_fails`: errors on invalid toml
- [ ] Manual: restart MCP server, confirm backward compat with existing registries