### PR TITLE
feat: add skillet-dev skill (dogfooding)

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -127,6 +127,8 @@ mod tests {
                 files: HashMap::new(),
                 published: None,
                 has_content: true,
+                content_hash: None,
+                integrity_ok: None,
             }],
         }
     }

--- a/test-registry/joshrotenberg/skillet-dev/SKILL.md
+++ b/test-registry/joshrotenberg/skillet-dev/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: skillet-dev
+description: Skillet codebase conventions, architecture, and contribution workflow. Use when working on the skillet codebase.
+---
+
+## What is Skillet
+
+Skillet is an MCP-native skill registry for AI agents. It serves skills (structured prompts with metadata) from a git-backed registry via MCP tools and resource templates. Think crates.io or Homebrew, but for agent skills.
+
+Three-layer architecture:
+
+| Layer | Implementation | Purpose |
+|-------|---------------|---------|
+| Discovery index | Git repo, flat `owner/skill-name` dirs | Find skills, filter, resolve versions |
+| Content storage | Same git repo (skills are small) | Store skill.toml + SKILL.md packages |
+| MCP server | Rust, tower-mcp | Search, browse, fetch via tools + resource templates |
+
+## Module Map
+
+| File | Purpose |
+|------|---------|
+| `src/main.rs` | CLI args (clap), server startup, MCP router assembly, background refresh task |
+| `src/state.rs` | `AppState` (shared state), all data types: `SkillIndex`, `SkillEntry`, `SkillVersion`, `SkillSummary`, `SkillMetadata` |
+| `src/index.rs` | Registry loader -- walks `owner/skill-name/` dirs, parses skill.toml + SKILL.md, loads extra files, handles `versions.toml` multi-version support |
+| `src/bm25.rs` | Vendored BM25 search engine (from jpx-engine), simple plural stemmer, no serde |
+| `src/search.rs` | `SkillSearch` wrapper -- indexes skill metadata fields into BM25, rebuilt on refresh |
+| `src/integrity.rs` | Content hashing (SHA256) and `MANIFEST.sha256` verification |
+| `src/git.rs` | Git CLI operations: clone, pull, HEAD inspection for remote registries |
+| `src/tools/` | MCP tools: `search_skills`, `list_categories`, `list_skills_by_owner` |
+| `src/resources/` | MCP resource templates: `skill_content`, `skill_metadata`, `skill_files` |
+
+## Key Patterns
+
+### AppState with RwLock
+
+`AppState` holds `RwLock<SkillIndex>` and `RwLock<SkillSearch>`. Both are rebuilt together when the remote registry is refreshed. Tools and resources acquire read locks; the refresh task acquires write locks.
+
+### tower-mcp Tool Pattern
+
+Tools use `ToolBuilder` with the extractor pattern:
+
+```rust
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("tool_name")
+        .description("...")
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<InputType>| async move {
+                let index = state.index.read().await;
+                // ... use index ...
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}
+```
+
+Input types derive `Deserialize` and `JsonSchema`. The `State` extractor provides access to `AppState`. Return `CallToolResult::text(...)`.
+
+### Resource Template Pattern
+
+Resource templates use `ResourceTemplateBuilder` with a URI template and closure handler:
+
+```rust
+pub fn build(state: Arc<AppState>) -> ResourceTemplate {
+    ResourceTemplateBuilder::new("skillet://skills/{owner}/{name}")
+        .name("Skill Content")
+        .description("...")
+        .mime_type("text/markdown")
+        .handler(move |uri: String, vars: HashMap<String, String>| {
+            let state = state.clone();
+            async move {
+                let owner = vars.get("owner").cloned().unwrap_or_default();
+                // ... look up skill, return content ...
+                Ok(ReadResourceResult { contents: vec![...], meta: None })
+            }
+        })
+}
+```
+
+URI variables are extracted from the `vars` HashMap.
+
+## Adding a Tool
+
+1. Create `src/tools/my_tool.rs` with a `build(state: Arc<AppState>) -> Tool` function
+2. Add `pub mod my_tool;` to `src/tools/mod.rs`
+3. In `main.rs`: call `let my_tool = tools::my_tool::build(state.clone());` and add `.tool(my_tool)` to the router
+
+## Adding a Resource Template
+
+1. Create `src/resources/my_resource.rs` with a `build(state: Arc<AppState>) -> ResourceTemplate` function
+2. Add `pub mod my_resource;` to `src/resources/mod.rs`
+3. In `main.rs`: call `let my_resource = resources::my_resource::build(state.clone());` and add `.resource_template(my_resource)` to the router
+
+## Test Registry
+
+`test-registry/` is the development registry. The server defaults to this directory when no `--registry` or `--remote` flag is provided. Adding skills there provides integration test coverage -- the existing `test_load_index_from_test_registry` test validates all skills in the directory parse correctly.
+
+Skill directory layout: `test-registry/owner/skill-name/` containing `skill.toml` and `SKILL.md`. Optional subdirectories: `scripts/`, `references/`, `assets/`.
+
+## Search
+
+BM25 index over skill metadata fields (owner, name, description, trigger, categories, tags). Rebuilt on each registry refresh. Structured filters (category, tag, verified_with) are applied post-search. Wildcard query `*` returns all skills with filters only.
+
+The simple stemmer handles plurals but not verb forms -- "testing" and "test" are different tokens.
+
+## Pre-commit Checks
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --lib --all-features
+cargo test --test '*' --all-features
+```
+
+## Git Workflow
+
+- Create feature branches from main: `feat/`, `fix/`, `docs/`, `refactor/`
+- Use conventional commits: `feat: add X`, `fix: resolve Y`
+- Do not merge PRs -- the maintainer handles merges
+- After a PR is merged: checkout main and pull before starting new work
+
+For deeper module-level reference, fetch `skillet://files/joshrotenberg/skillet-dev/references/ARCHITECTURE.md`.

--- a/test-registry/joshrotenberg/skillet-dev/references/ARCHITECTURE.md
+++ b/test-registry/joshrotenberg/skillet-dev/references/ARCHITECTURE.md
@@ -1,0 +1,158 @@
+# Skillet Architecture Reference
+
+## Data Flow
+
+```
+git checkout (or local dir)
+    |
+    v
+load_config() --> RegistryConfig (from config.toml or defaults)
+load_index()  --> SkillIndex (walks owner/skill-name dirs)
+    |
+    v
+SkillSearch::build(&index) --> BM25 index over metadata fields
+    |
+    v
+AppState::new(path, index, search, config) --> Arc<AppState>
+    |
+    +---> tools/resources serve requests via read locks
+    +---> spawn_refresh_task pulls, compares HEAD, reloads both index + search
+```
+
+## Module Reference
+
+### main.rs
+
+Entry point. Parses CLI args with clap:
+
+- `--registry <path>`: local registry directory
+- `--remote <url>`: git URL to clone/pull
+- `--refresh-interval <duration>`: pull interval (default "5m")
+- `--cache-dir <path>`: where to clone remotes
+- `--subdir <path>`: subdirectory within registry containing skills
+
+Key functions:
+
+- `main()`: parses args, resolves registry path, loads index, builds router, starts stdio transport
+- `spawn_refresh_task()`: background tokio task that periodically pulls from remote, compares HEAD hash, reloads index + search if changed
+- `parse_duration()`: parses "5m", "1h", "30s", "0" into `Duration`
+- `cache_dir_for_url()`: derives cache path from remote URL
+
+### state.rs
+
+Shared application state and all data model types.
+
+**AppState**: holds `RwLock<SkillIndex>`, `RwLock<SkillSearch>`, `registry_path`, and `config`. Constructor returns `Arc<Self>`.
+
+**SkillIndex**: `HashMap<(owner, name), SkillEntry>` + `BTreeMap<category, count>`.
+
+**SkillEntry**: owner, name, and `Vec<SkillVersion>`. The `latest()` method returns the last non-yanked version.
+
+**SkillVersion**: version string, parsed `SkillMetadata`, raw `skill_md` and `skill_toml_raw` strings, extra `files` HashMap, `published` timestamp, `has_content` flag (false for historical versions), `content_hash`, and `integrity_ok`.
+
+**SkillSummary**: serializable summary for search results. Built from `SkillEntry` via `SkillSummary::from_entry()`. Includes version count, available versions, integrity status.
+
+**SkillMetadata / SkillInfo**: parsed skill.toml structure with classification (categories, tags) and compatibility (requires_tool_use, verified_with, etc.).
+
+### index.rs
+
+Registry loading from disk.
+
+**load_config()**: reads `config.toml` from registry root. Returns defaults if absent, errors if malformed.
+
+**load_index()**: walks the registry directory two levels deep (owner -> skill-name). Calls `load_skill()` for each, accumulates category counts. Warns and skips invalid skills.
+
+**load_skill()**: reads `skill.toml` and `SKILL.md`, validates owner/name match directory structure, collects extra files from `scripts/`, `references/`, `assets/`. If `versions.toml` exists, builds multi-version entry; otherwise single-version.
+
+**load_versions_manifest()**: parses `versions.toml`. Latest version (last entry) gets full content from disk. Historical versions are placeholders with `has_content = false`. Validates last version matches `skill.toml` version.
+
+**verify_manifest()**: reads `MANIFEST.sha256`, compares computed hashes. Returns `(composite_hash, Option<bool>)`.
+
+**load_extra_files()**: scans `scripts/`, `references/`, `assets/` subdirectories for text files. Determines mime type by extension.
+
+### bm25.rs
+
+Vendored BM25 search engine.
+
+**Bm25Index**: inverted index with term frequencies and document metadata. Built from JSON documents via `Bm25Index::build()`. Search via `Bm25Index::search(query, top_k)` returns `Vec<SearchResult>` sorted by score.
+
+**IndexOptions**: configures fields to index, ID field, stopwords, case normalization, BM25 k1/b parameters.
+
+**stem_simple()**: plural stemmer handling -s, -ies, -xes, -zes, -sses, -shes suffixes. Does not handle verb forms (-ing, -ed).
+
+### search.rs
+
+**SkillSearch**: wraps `Bm25Index` for skill-specific search. Indexes fields: owner, name, description, trigger, categories, tags. Each skill is a JSON document with `id` = "owner/name".
+
+**build()**: constructs from `SkillIndex`, returns `SkillSearch`.
+
+**search()**: delegates to BM25, parses "owner/name" IDs back into tuples. Returns `Vec<(owner, name, score)>`.
+
+### integrity.rs
+
+Content hashing and verification.
+
+**compute_hashes()**: SHA256 of `skill.toml`, `SKILL.md`, and extra files. Produces `ContentHashes` with per-file hashes (BTreeMap) and a composite hash (hash of sorted path+hash pairs).
+
+**parse_manifest()**: reads `MANIFEST.sha256` format: `<hash>  <path>` lines, composite uses `*` as path. Comments (#) and blank lines ignored.
+
+**verify()**: compares computed vs expected hashes. Returns list of mismatch descriptions. Checks: composite mismatch, per-file content mismatch, files in manifest but not on disk, files on disk but not in manifest.
+
+**sha256_hex()**: returns `"sha256:<hex>"` string.
+
+### git.rs
+
+Git CLI wrappers.
+
+- `clone()`: shallow clone (`--depth 1`) to target directory
+- `pull()`: git pull in existing clone
+- `head()`: `git rev-parse HEAD` to get current commit hash
+- `clone_or_pull()`: clone if target doesn't exist, pull if it does
+
+### tools/search_skills.rs
+
+Full-text search tool. Input: query, optional category/tag/verified_with filters. Wildcard `*` returns all skills. BM25 results are looked up in the index to build `SkillSummary` objects. Structured filters applied post-search. Output is formatted markdown.
+
+### tools/list_categories.rs
+
+Returns all categories with skill counts from `SkillIndex.categories` (BTreeMap).
+
+### tools/list_skills_by_owner.rs
+
+Filters index by owner, returns all matching skills as summaries.
+
+### resources/skill_content.rs
+
+Two resource templates:
+- `skillet://skills/{owner}/{name}` -- returns `SKILL.md` of latest version
+- `skillet://skills/{owner}/{name}/{version}` -- returns `SKILL.md` of specific version (errors if `has_content` is false for historical versions)
+
+### resources/skill_metadata.rs
+
+`skillet://metadata/{owner}/{name}` -- returns raw `skill.toml` content of latest version.
+
+### resources/skill_files.rs
+
+`skillet://files/{owner}/{name}/{path}` -- returns content of extra files (scripts/, references/, assets/). Path is matched against `SkillVersion.files` HashMap keys.
+
+## Refresh Cycle
+
+When running with `--remote`:
+
+1. `spawn_refresh_task` starts a tokio background loop
+2. Every `refresh_interval`, it runs `git pull` in a blocking task
+3. Compares HEAD before/after pull
+4. If HEAD changed: calls `load_index()` and `SkillSearch::build()`, acquires write locks on both, replaces state
+5. If HEAD unchanged: no-op (debug log)
+6. Errors are logged as warnings; the current index is preserved
+
+## How Tools Use State
+
+All tools and resource handlers receive `Arc<AppState>` at build time. At request time they:
+
+1. Acquire a read lock: `state.index.read().await` (or `state.search.read().await`)
+2. Look up data in the index
+3. Build response
+4. Lock is dropped when the guard goes out of scope
+
+This allows concurrent reads. Write locks are only held briefly during refresh.

--- a/test-registry/joshrotenberg/skillet-dev/skill.toml
+++ b/test-registry/joshrotenberg/skillet-dev/skill.toml
@@ -1,0 +1,23 @@
+[skill]
+name = "skillet-dev"
+owner = "joshrotenberg"
+version = "2026.02.24"
+description = "Skillet codebase conventions, architecture, and contribution workflow"
+trigger = "Use when working on the skillet codebase (the MCP skill registry itself)"
+license = "MIT"
+
+[skill.author]
+name = "Josh Rotenberg"
+github = "joshrotenberg"
+
+[skill.classification]
+categories = ["development", "rust"]
+tags = ["skillet", "mcp", "tower-mcp", "registry", "skills"]
+
+[skill.compatibility]
+requires_tool_use = true
+requires_vision = false
+min_context_tokens = 4096
+required_tools = ["bash", "read", "write", "edit"]
+required_mcp_servers = []
+verified_with = ["claude-opus-4-6"]


### PR DESCRIPTION
## Summary

- Add `joshrotenberg/skillet-dev` skill to test-registry with project architecture, module map, key patterns (ToolBuilder/ResourceTemplateBuilder), how-to guides for adding tools/resources, and contribution workflow
- Include `references/ARCHITECTURE.md` with detailed module-level reference, data flow diagram, and refresh cycle documentation
- Fix missing `content_hash`/`integrity_ok` fields in `search.rs` test helper (regression from content-hashing merge)

## Test plan

- [x] `cargo test --all-features` passes (51 tests, including `test_load_index_from_test_registry`)
- [x] `cargo fmt` and `cargo clippy -D warnings` clean
- [x] `search_skills("skillet")` finds both `skillet/setup` and `joshrotenberg/skillet-dev`
- [x] `search_skills("mcp development")` ranks `skillet-dev` first
- [x] `skillet://skills/joshrotenberg/skillet-dev` returns SKILL.md
- [x] `skillet://metadata/joshrotenberg/skillet-dev` returns skill.toml
- [x] `skillet://files/joshrotenberg/skillet-dev/references/ARCHITECTURE.md` returns reference doc