### PR TITLE
fix: sort wildcard search results by owner/name

### DIFF
--- a/src/tools/search_skills.rs
+++ b/src/tools/search_skills.rs
@@ -41,12 +41,14 @@ pub fn build(state: Arc<AppState>) -> Tool {
                 let index = state.index.read().await;
 
                 let results: Vec<SkillSummary> = if input.query == "*" {
-                    // Wildcard: return all skills, apply structured filters only
-                    index
+                    // Wildcard: return all skills sorted by owner/name
+                    let mut all: Vec<_> = index
                         .skills
                         .values()
                         .filter_map(SkillSummary::from_entry)
-                        .collect()
+                        .collect();
+                    all.sort_by(|a, b| (&a.owner, &a.name).cmp(&(&b.owner, &b.name)));
+                    all
                 } else {
                     // BM25 search, then look up summaries
                     let search = state.search.read().await;


### PR DESCRIPTION
## Summary

- Sort `search_skills` wildcard (`*`) results by `(owner, name)` for deterministic output
- BM25 search results were already ordered by score, so only the wildcard path needed fixing

Closes #16.

## Test plan

- [x] All 64 tests pass
- [ ] Manual: run `search_skills` with `*` multiple times, verify consistent ordering