### PR TITLE
test: add MCP server integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "skillet"
 path = "src/main.rs"
 
 [dependencies]
-tower-mcp = "0.6"
+tower-mcp = { version = "0.6", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Add 8 integration tests using tower-mcp's `TestClient` that exercise the full MCP request path (JSON-RPC -> router -> tool/resource handler -> response) against the test-registry
- Enable the `testing` feature on tower-mcp
- Extract `build_router()` from `run_serve_inner()` to share router construction between the server and tests

Tests cover: initialize, list tools, search (keyword + wildcard), list categories, list by owner, read skill content resource, read metadata resource.

Closes #17.

## Test plan

- [x] All 72 tests pass (64 existing + 8 new MCP integration tests)
- [x] `cargo clippy` and `cargo fmt` clean