### PR TITLE
Add Dockerfile and CI workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target/
+.git/
+.github/
+.claude/
+CLAUDE.md
+docs/
+test-registry/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - run: cargo test --lib --all-features
+      - run: cargo test --test '*' --all-features
+      - run: cargo doc --no-deps --all-features

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM rust:1.90-slim AS builder
+
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY src/ src/
+
+RUN cargo build --release --bin skillet
+
+FROM debian:trixie-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/skillet /usr/local/bin/skillet
+
+ENTRYPOINT ["skillet"]


### PR DESCRIPTION
## Summary

- Multi-stage Dockerfile: `rust:1.90-slim` builder, `debian:trixie-slim` runtime with git + ca-certificates
- Docker publish workflow: triggers on version tags, pushes to `ghcr.io/joshrotenberg/grimoire`
- CI workflow: fmt, clippy, test (lib + integration), doc on PRs and main pushes
- Image size: ~300MB (git accounts for most of it)

## Usage

```json
{
  "mcpServers": {
    "skillet": {
      "command": "docker",
      "args": [
        "run", "--rm", "-i",
        "ghcr.io/joshrotenberg/grimoire",
        "--remote", "https://github.com/joshrotenberg/skillet-registry.git"
      ]
    }
  }
}
```

## Test plan

- [x] `docker build -t skillet:test .` succeeds
- [x] `docker run --rm skillet:test --help` prints usage
- [ ] CI workflow passes on this PR
- [ ] Docker workflow runs on tag push (test after merge)

Closes #24