### PR TITLE
refactor: extract lib.rs from binary crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/joshrotenberg/grimoire"
 keywords = ["mcp", "skills", "ai-agents", "registry"]
 categories = ["development-tools", "command-line-utilities"]
 
+[lib]
+name = "skillet_mcp"
+path = "src/lib.rs"
+
 [[bin]]
 name = "skillet"
 path = "src/main.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,16 @@
+//! Skillet: a skill registry toolkit for AI agents.
+//!
+//! This library provides the core functionality for loading, searching,
+//! validating, packing, and publishing skill registries. The binary crate
+//! adds the CLI (clap) and MCP server (tower-mcp) on top.
+
+pub mod bm25;
+pub mod git;
+pub mod index;
+pub mod integrity;
+pub mod pack;
+pub mod publish;
+pub mod registry;
+pub mod search;
+pub mod state;
+pub mod validate;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,0 +1,236 @@
+//! Registry management: initialization and utility functions.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Parse a human-friendly duration string like "5m", "1h", "30s", or "0".
+pub fn parse_duration(s: &str) -> anyhow::Result<Duration> {
+    let s = s.trim();
+    if s == "0" {
+        return Ok(Duration::ZERO);
+    }
+
+    let (num, suffix) = s.split_at(s.find(|c: char| !c.is_ascii_digit()).unwrap_or(s.len()));
+    let num: u64 = num
+        .parse()
+        .map_err(|_| anyhow::anyhow!("Invalid duration number: {s}"))?;
+
+    let secs = match suffix {
+        "s" | "" => num,
+        "m" => num * 60,
+        "h" => num * 3600,
+        _ => anyhow::bail!("Unknown duration suffix: {suffix} (use s, m, or h)"),
+    };
+
+    Ok(Duration::from_secs(secs))
+}
+
+/// Derive a cache directory from the remote URL.
+///
+/// Turns `https://github.com/owner/repo.git` into `<base>/owner_repo`.
+pub fn cache_dir_for_url(base: &Path, url: &str) -> PathBuf {
+    let slug: String = url
+        .trim_end_matches(".git")
+        .rsplit('/')
+        .take(2)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<Vec<_>>()
+        .join("_");
+
+    let slug = if slug.is_empty() {
+        "default".to_string()
+    } else {
+        slug
+    };
+
+    base.join(slug)
+}
+
+/// Default cache directory for cloned remote registries.
+pub fn default_cache_dir() -> PathBuf {
+    if let Ok(home) = std::env::var("HOME") {
+        PathBuf::from(home).join(".cache").join("skillet")
+    } else {
+        PathBuf::from("/tmp").join("skillet")
+    }
+}
+
+/// Initialize a new skill registry at the given path.
+///
+/// Creates a git repo with `config.toml`, `README.md`, and `.gitignore`,
+/// then makes an initial commit.
+pub fn init_registry(path: &Path, name: &str) -> anyhow::Result<()> {
+    std::fs::create_dir_all(path)?;
+
+    // config.toml
+    let config = format!("[registry]\nname = \"{name}\"\nversion = 1\n", name = name);
+    std::fs::write(path.join("config.toml"), config)?;
+
+    // README.md
+    let readme = format!(
+        "# {name}\n\
+         \n\
+         A skill registry for [skillet](https://github.com/joshrotenberg/grimoire).\n\
+         \n\
+         ## Adding skills\n\
+         \n\
+         Create a directory for your skill:\n\
+         \n\
+         ```\n\
+         mkdir -p your-name/skill-name\n\
+         ```\n\
+         \n\
+         Add the two required files:\n\
+         \n\
+         - `skill.toml` -- metadata (name, description, categories, tags)\n\
+         - `SKILL.md` -- the skill prompt (Agent Skills spec compatible)\n\
+         \n\
+         Validate with `skillet validate your-name/skill-name`.\n\
+         \n\
+         ## Serving\n\
+         \n\
+         ```bash\n\
+         # Local\n\
+         skillet --registry .\n\
+         \n\
+         # Remote (after pushing to git)\n\
+         skillet --remote <git-url>\n\
+         ```\n",
+        name = name
+    );
+    std::fs::write(path.join("README.md"), readme)?;
+
+    // .gitignore
+    std::fs::write(path.join(".gitignore"), ".DS_Store\n")?;
+
+    // git init
+    let output = std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(path)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git init failed: {stderr}");
+    }
+
+    // Set local git config if no global identity exists (e.g. in CI)
+    let has_identity = std::process::Command::new("git")
+        .args(["config", "user.name"])
+        .current_dir(path)
+        .output()
+        .is_ok_and(|o| o.status.success());
+
+    if !has_identity {
+        let _ = std::process::Command::new("git")
+            .args(["config", "user.name", "skillet"])
+            .current_dir(path)
+            .output();
+        let _ = std::process::Command::new("git")
+            .args(["config", "user.email", "skillet@localhost"])
+            .current_dir(path)
+            .output();
+    }
+
+    // initial commit
+    let output = std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(path)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git add failed: {stderr}");
+    }
+
+    let output = std::process::Command::new("git")
+        .args(["commit", "-m", "Initialize skill registry"])
+        .current_dir(path)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git commit failed: {stderr}");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_duration_seconds() {
+        assert_eq!(parse_duration("30s").unwrap(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_parse_duration_minutes() {
+        assert_eq!(parse_duration("5m").unwrap(), Duration::from_secs(300));
+    }
+
+    #[test]
+    fn test_parse_duration_hours() {
+        assert_eq!(parse_duration("1h").unwrap(), Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn test_parse_duration_zero() {
+        assert_eq!(parse_duration("0").unwrap(), Duration::ZERO);
+    }
+
+    #[test]
+    fn test_parse_duration_bare_number() {
+        assert_eq!(parse_duration("60").unwrap(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_cache_dir_for_url_github() {
+        let base = PathBuf::from("/tmp/skillet");
+        let dir = cache_dir_for_url(&base, "https://github.com/owner/repo.git");
+        assert_eq!(dir, PathBuf::from("/tmp/skillet/owner_repo"));
+    }
+
+    #[test]
+    fn test_cache_dir_for_url_no_git_suffix() {
+        let base = PathBuf::from("/tmp/skillet");
+        let dir = cache_dir_for_url(&base, "https://github.com/owner/repo");
+        assert_eq!(dir, PathBuf::from("/tmp/skillet/owner_repo"));
+    }
+
+    #[test]
+    fn test_init_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("my-registry");
+
+        init_registry(&registry_path, "my-registry").unwrap();
+
+        // config.toml exists with correct name
+        let config = std::fs::read_to_string(registry_path.join("config.toml")).unwrap();
+        assert!(config.contains("name = \"my-registry\""));
+        assert!(config.contains("version = 1"));
+
+        // README.md exists
+        assert!(registry_path.join("README.md").exists());
+
+        // .gitignore exists
+        assert!(registry_path.join(".gitignore").exists());
+
+        // git repo initialized with a commit
+        let output = std::process::Command::new("git")
+            .args(["log", "--oneline"])
+            .current_dir(&registry_path)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let log = String::from_utf8_lossy(&output.stdout);
+        assert!(log.contains("Initialize skill registry"));
+
+        // Can be loaded as a valid registry
+        let loaded_config = crate::index::load_config(&registry_path).unwrap();
+        assert_eq!(loaded_config.registry.name, "my-registry");
+    }
+}

--- a/src/resources/skill_content.rs
+++ b/src/resources/skill_content.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
 use tower_mcp::resource::{ResourceTemplate, ResourceTemplateBuilder};
 
-use crate::state::AppState;
+use skillet_mcp::state::AppState;
 
 /// Build the skill content resource template.
 ///

--- a/src/resources/skill_files.rs
+++ b/src/resources/skill_files.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
 use tower_mcp::resource::{ResourceTemplate, ResourceTemplateBuilder};
 
-use crate::state::AppState;
+use skillet_mcp::state::AppState;
 
 /// Build the skillpack files resource template.
 ///

--- a/src/resources/skill_metadata.rs
+++ b/src/resources/skill_metadata.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
 use tower_mcp::resource::{ResourceTemplate, ResourceTemplateBuilder};
 
-use crate::state::AppState;
+use skillet_mcp::state::AppState;
 
 /// Build the skill metadata resource template.
 ///

--- a/src/tools/list_categories.rs
+++ b/src/tools/list_categories.rs
@@ -7,7 +7,7 @@ use tower_mcp::{
     extract::{Json, State},
 };
 
-use crate::state::AppState;
+use skillet_mcp::state::AppState;
 
 pub fn build(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_categories")

--- a/src/tools/list_skills_by_owner.rs
+++ b/src/tools/list_skills_by_owner.rs
@@ -9,7 +9,7 @@ use tower_mcp::{
     extract::{Json, State},
 };
 
-use crate::state::{AppState, SkillSummary};
+use skillet_mcp::state::{AppState, SkillSummary};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListByOwnerInput {

--- a/src/tools/search_skills.rs
+++ b/src/tools/search_skills.rs
@@ -9,7 +9,7 @@ use tower_mcp::{
     extract::{Json, State},
 };
 
-use crate::state::{AppState, SkillSummary};
+use skillet_mcp::state::{AppState, SkillSummary};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SearchSkillsInput {


### PR DESCRIPTION
## Summary

Splits the codebase into a library crate (`skillet_mcp`) and a thin binary crate. Closes #41.

**Library (`src/lib.rs`)** -- pure logic, no clap/tower-mcp:
- `bm25`, `git`, `index`, `integrity`, `pack`, `publish`, `search`, `state`, `validate`
- New `registry` module: `init_registry`, `parse_duration`, `cache_dir_for_url`, `default_cache_dir` (extracted from main.rs)
- 65 unit tests

**Binary (`src/main.rs`)** -- thin CLI + MCP server glue:
- CLI parsing (clap), MCP server setup, transport management
- `tools/` and `resources/` modules (tower-mcp dependent)
- 8 MCP integration tests

## What changes

- Added `[lib]` section to Cargo.toml (`name = "skillet_mcp"`)
- Created `src/lib.rs` re-exporting library modules
- Created `src/registry.rs` (extracted from main.rs)
- Updated `tools/*.rs` and `resources/*.rs`: `crate::state` -> `skillet_mcp::state`
- Slimmed `main.rs` to CLI + server glue (no more library code)

## Benefits

- `cargo test --lib` works (65 tests)
- Doc-tests enabled
- CLI and MCP server share library code, no duplication when adding CLI skill operations (#35)
- Downstream consumers can depend on `skillet_mcp` without pulling in clap/tower-mcp

## Test plan

- [x] `cargo test --lib --all-features` -- 65 passed
- [x] `cargo test --all-features` -- 73 passed (65 lib + 8 bin)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo doc --no-deps --all-features` -- clean
- [x] `cargo fmt --all -- --check` -- clean