### PR TITLE
feat: skill installation CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,6 +1189,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "thiserror",
  "tokio",
  "toml",
  "tower-mcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ anyhow = "1"
 sha2 = "0.10"
 hex = "0.4"
 notify-debouncer-mini = "0.5"
+thiserror = "2"
 tempfile = "3.26.0"
 
 # The profile that 'dist' will build with

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,420 @@
+//! CLI configuration: config file loading, install targets, and shared utilities.
+//!
+//! The skillet config file lives at `~/.config/skillet/config.toml` and controls
+//! default install targets, registries, and other CLI behavior.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level skillet CLI configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SkilletConfig {
+    pub install: InstallConfig,
+    pub registries: RegistriesConfig,
+}
+
+/// `[install]` section: default targets and global flag.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct InstallConfig {
+    pub targets: Vec<String>,
+    pub global: bool,
+}
+
+impl Default for InstallConfig {
+    fn default() -> Self {
+        Self {
+            targets: vec!["agents".to_string()],
+            global: false,
+        }
+    }
+}
+
+/// `[registries]` section: default local and remote registries.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RegistriesConfig {
+    pub local: Vec<PathBuf>,
+    pub remote: Vec<String>,
+}
+
+/// An agent platform to install skills into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InstallTarget {
+    Agents,
+    Claude,
+    Cursor,
+    Copilot,
+    Windsurf,
+    Gemini,
+}
+
+/// All known install targets.
+pub const ALL_TARGETS: &[InstallTarget] = &[
+    InstallTarget::Agents,
+    InstallTarget::Claude,
+    InstallTarget::Cursor,
+    InstallTarget::Copilot,
+    InstallTarget::Windsurf,
+    InstallTarget::Gemini,
+];
+
+impl InstallTarget {
+    /// Parse a target string. Returns `Ok(None)` for "all" (caller expands).
+    pub fn parse(s: &str) -> anyhow::Result<Option<Self>> {
+        match s.to_lowercase().as_str() {
+            "all" => Ok(None),
+            "agents" => Ok(Some(Self::Agents)),
+            "claude" => Ok(Some(Self::Claude)),
+            "cursor" => Ok(Some(Self::Cursor)),
+            "copilot" => Ok(Some(Self::Copilot)),
+            "windsurf" => Ok(Some(Self::Windsurf)),
+            "gemini" => Ok(Some(Self::Gemini)),
+            other => anyhow::bail!(
+                "Unknown install target: {other}. \
+                 Valid targets: agents, claude, cursor, copilot, windsurf, gemini, all"
+            ),
+        }
+    }
+
+    /// Project-local install directory for a skill.
+    pub fn project_dir(&self, name: &str) -> PathBuf {
+        match self {
+            Self::Agents => PathBuf::from(format!(".agents/skills/{name}/")),
+            Self::Claude => PathBuf::from(format!(".claude/skills/{name}/")),
+            Self::Cursor => PathBuf::from(format!(".cursor/skills/{name}/")),
+            Self::Copilot => PathBuf::from(format!(".github/skills/{name}/")),
+            Self::Windsurf => PathBuf::from(format!(".windsurf/skills/{name}/")),
+            Self::Gemini => PathBuf::from(format!(".gemini/skills/{name}/")),
+        }
+    }
+
+    /// Global install directory for a skill.
+    pub fn global_dir(&self, name: &str) -> PathBuf {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+        match self {
+            Self::Agents => PathBuf::from(format!("{home}/.agents/skills/{name}/")),
+            Self::Claude => PathBuf::from(format!("{home}/.claude/skills/{name}/")),
+            Self::Cursor => PathBuf::from(format!("{home}/.cursor/skills/{name}/")),
+            Self::Copilot => PathBuf::from(format!("{home}/.copilot/skills/{name}/")),
+            Self::Windsurf => PathBuf::from(format!("{home}/.codeium/windsurf/skills/{name}/")),
+            Self::Gemini => PathBuf::from(format!("{home}/.gemini/skills/{name}/")),
+        }
+    }
+
+    /// Human-readable name.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Agents => "agents",
+            Self::Claude => "claude",
+            Self::Cursor => "cursor",
+            Self::Copilot => "copilot",
+            Self::Windsurf => "windsurf",
+            Self::Gemini => "gemini",
+        }
+    }
+}
+
+impl std::fmt::Display for InstallTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Load CLI configuration from `~/.config/skillet/config.toml`.
+///
+/// Returns defaults if the file is absent. Errors if present but malformed.
+pub fn load_config() -> anyhow::Result<SkilletConfig> {
+    let path = config_dir().join("config.toml");
+    if !path.is_file() {
+        return Ok(SkilletConfig::default());
+    }
+    load_config_from(&path)
+}
+
+/// Load CLI configuration from a specific path (for testing).
+pub fn load_config_from(path: &Path) -> anyhow::Result<SkilletConfig> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("Failed to read {}: {e}", path.display()))?;
+    let config: SkilletConfig = toml::from_str(&raw)
+        .map_err(|e| anyhow::anyhow!("Failed to parse {}: {e}", path.display()))?;
+    Ok(config)
+}
+
+/// Resolve install targets from CLI flags and config.
+///
+/// Priority: flag targets > config targets > default ("agents").
+pub fn resolve_targets(
+    flag_targets: &[String],
+    config: &SkilletConfig,
+) -> anyhow::Result<Vec<InstallTarget>> {
+    let raw = if !flag_targets.is_empty() {
+        flag_targets
+    } else if !config.install.targets.is_empty() {
+        &config.install.targets
+    } else {
+        return Ok(vec![InstallTarget::Agents]);
+    };
+
+    let mut targets = Vec::new();
+    for s in raw {
+        match InstallTarget::parse(s)? {
+            Some(t) => {
+                if !targets.contains(&t) {
+                    targets.push(t);
+                }
+            }
+            None => {
+                // "all" -- expand to all targets
+                for &t in ALL_TARGETS {
+                    if !targets.contains(&t) {
+                        targets.push(t);
+                    }
+                }
+            }
+        }
+    }
+    Ok(targets)
+}
+
+/// The skillet config directory: `~/.config/skillet/`.
+pub fn config_dir() -> PathBuf {
+    if let Ok(home) = std::env::var("HOME") {
+        PathBuf::from(home).join(".config").join("skillet")
+    } else {
+        PathBuf::from("/tmp").join("skillet").join("config")
+    }
+}
+
+/// Current time as ISO 8601 string (UTC).
+///
+/// Uses `std::time` to avoid adding a chrono dependency.
+pub fn now_iso8601() -> String {
+    let now = std::time::SystemTime::now();
+    let duration = now
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = duration.as_secs();
+
+    let days = secs / 86400;
+    let time_of_day = secs % 86400;
+    let hours = time_of_day / 3600;
+    let minutes = (time_of_day % 3600) / 60;
+    let seconds = time_of_day % 60;
+
+    // Civil date from days since epoch (algorithm from Howard Hinnant)
+    let z = days as i64 + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = (z - era * 146097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+
+    format!("{y:04}-{m:02}-{d:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_load_defaults_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nonexistent.toml");
+        // load_config_from should fail on missing file, but load_config()
+        // returns defaults. Test the default path:
+        let config = SkilletConfig::default();
+        assert_eq!(config.install.targets, vec!["agents"]);
+        assert!(!config.install.global);
+        assert!(config.registries.local.is_empty());
+        assert!(config.registries.remote.is_empty());
+
+        // load_config_from on missing file should error
+        assert!(load_config_from(&path).is_err());
+    }
+
+    #[test]
+    fn test_parse_full_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+[install]
+targets = ["claude", "cursor"]
+global = true
+
+[registries]
+local = ["/path/to/local"]
+remote = ["https://github.com/owner/repo.git"]
+"#,
+        )
+        .unwrap();
+
+        let config = load_config_from(&path).unwrap();
+        assert_eq!(config.install.targets, vec!["claude", "cursor"]);
+        assert!(config.install.global);
+        assert_eq!(
+            config.registries.local,
+            vec![PathBuf::from("/path/to/local")]
+        );
+        assert_eq!(
+            config.registries.remote,
+            vec!["https://github.com/owner/repo.git"]
+        );
+    }
+
+    #[test]
+    fn test_parse_partial_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+[install]
+targets = ["gemini"]
+"#,
+        )
+        .unwrap();
+
+        let config = load_config_from(&path).unwrap();
+        assert_eq!(config.install.targets, vec!["gemini"]);
+        assert!(!config.install.global);
+        assert!(config.registries.local.is_empty());
+    }
+
+    #[test]
+    fn test_malformed_toml_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(&path, "this is not valid toml {{{").unwrap();
+        assert!(load_config_from(&path).is_err());
+    }
+
+    #[test]
+    fn test_resolve_targets_flag_overrides_config() {
+        let config = SkilletConfig {
+            install: InstallConfig {
+                targets: vec!["claude".to_string()],
+                global: false,
+            },
+            registries: RegistriesConfig::default(),
+        };
+        let flags = vec!["cursor".to_string()];
+        let targets = resolve_targets(&flags, &config).unwrap();
+        assert_eq!(targets, vec![InstallTarget::Cursor]);
+    }
+
+    #[test]
+    fn test_resolve_targets_falls_back_to_config() {
+        let config = SkilletConfig {
+            install: InstallConfig {
+                targets: vec!["claude".to_string(), "cursor".to_string()],
+                global: false,
+            },
+            registries: RegistriesConfig::default(),
+        };
+        let targets = resolve_targets(&[], &config).unwrap();
+        assert_eq!(targets, vec![InstallTarget::Claude, InstallTarget::Cursor]);
+    }
+
+    #[test]
+    fn test_resolve_targets_default_agents() {
+        let config = SkilletConfig {
+            install: InstallConfig {
+                targets: Vec::new(),
+                global: false,
+            },
+            registries: RegistriesConfig::default(),
+        };
+        let targets = resolve_targets(&[], &config).unwrap();
+        assert_eq!(targets, vec![InstallTarget::Agents]);
+    }
+
+    #[test]
+    fn test_all_expands_to_all_targets() {
+        let config = SkilletConfig::default();
+        let flags = vec!["all".to_string()];
+        let targets = resolve_targets(&flags, &config).unwrap();
+        assert_eq!(targets.len(), ALL_TARGETS.len());
+        for &t in ALL_TARGETS {
+            assert!(targets.contains(&t));
+        }
+    }
+
+    #[test]
+    fn test_invalid_target_errors() {
+        let result = InstallTarget::parse("vscode");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_project_dir_paths() {
+        assert_eq!(
+            InstallTarget::Agents.project_dir("my-skill"),
+            PathBuf::from(".agents/skills/my-skill/")
+        );
+        assert_eq!(
+            InstallTarget::Claude.project_dir("my-skill"),
+            PathBuf::from(".claude/skills/my-skill/")
+        );
+        assert_eq!(
+            InstallTarget::Cursor.project_dir("my-skill"),
+            PathBuf::from(".cursor/skills/my-skill/")
+        );
+        assert_eq!(
+            InstallTarget::Copilot.project_dir("my-skill"),
+            PathBuf::from(".github/skills/my-skill/")
+        );
+        assert_eq!(
+            InstallTarget::Windsurf.project_dir("my-skill"),
+            PathBuf::from(".windsurf/skills/my-skill/")
+        );
+        assert_eq!(
+            InstallTarget::Gemini.project_dir("my-skill"),
+            PathBuf::from(".gemini/skills/my-skill/")
+        );
+    }
+
+    #[test]
+    fn test_global_dir_paths() {
+        // Set HOME for deterministic test
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+        assert_eq!(
+            InstallTarget::Agents.global_dir("my-skill"),
+            PathBuf::from(format!("{home}/.agents/skills/my-skill/"))
+        );
+        assert_eq!(
+            InstallTarget::Copilot.global_dir("my-skill"),
+            PathBuf::from(format!("{home}/.copilot/skills/my-skill/"))
+        );
+        assert_eq!(
+            InstallTarget::Windsurf.global_dir("my-skill"),
+            PathBuf::from(format!("{home}/.codeium/windsurf/skills/my-skill/"))
+        );
+    }
+
+    #[test]
+    fn test_now_iso8601_format() {
+        let ts = now_iso8601();
+        assert_eq!(ts.len(), 20);
+        assert!(ts.ends_with('Z'));
+        assert_eq!(&ts[4..5], "-");
+        assert_eq!(&ts[7..8], "-");
+        assert_eq!(&ts[10..11], "T");
+    }
+
+    #[test]
+    fn test_dedup_targets() {
+        let config = SkilletConfig::default();
+        let flags = vec!["claude".to_string(), "claude".to_string()];
+        let targets = resolve_targets(&flags, &config).unwrap();
+        assert_eq!(targets, vec![InstallTarget::Claude]);
+    }
+}

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,0 +1,337 @@
+//! Core skill installation logic.
+//!
+//! Writes skill files to agent target directories and records entries
+//! in the installation manifest.
+
+use std::path::{Path, PathBuf};
+
+use crate::config::{self, InstallTarget};
+use crate::index::EXTRA_DIRS;
+use crate::integrity;
+use crate::manifest::{InstalledManifest, InstalledSkill};
+use crate::state::SkillVersion;
+
+/// Errors that can occur during skill installation.
+#[derive(Debug, thiserror::Error)]
+pub enum InstallError {
+    #[error("failed to create directory {path}: {source}")]
+    CreateDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to write {path}: {source}")]
+    WriteFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to resolve current directory: {0}")]
+    CurrentDir(std::io::Error),
+}
+
+/// Options controlling how a skill is installed.
+pub struct InstallOptions {
+    pub targets: Vec<InstallTarget>,
+    pub global: bool,
+    /// Registry identifier for the manifest entry.
+    /// Git URL for remotes, `local:<abs_path>` for local registries.
+    pub registry: String,
+}
+
+/// Result of installing a skill to a single target.
+pub struct InstallResult {
+    pub target: InstallTarget,
+    pub path: PathBuf,
+    pub files_written: Vec<String>,
+}
+
+/// Install a skill to all specified targets, updating the manifest.
+///
+/// Returns one `InstallResult` per target. Does NOT call `manifest::save()` --
+/// the caller should save once after all installs complete.
+pub fn install_skill(
+    owner: &str,
+    name: &str,
+    version: &SkillVersion,
+    options: &InstallOptions,
+    manifest: &mut InstalledManifest,
+) -> Result<Vec<InstallResult>, InstallError> {
+    let cwd = std::env::current_dir().map_err(InstallError::CurrentDir)?;
+    let checksum = integrity::sha256_hex(&version.skill_md);
+    let now = config::now_iso8601();
+    let mut results = Vec::new();
+
+    for &target in &options.targets {
+        let relative_dir = if options.global {
+            target.global_dir(name)
+        } else {
+            target.project_dir(name)
+        };
+
+        // Resolve to absolute path for the manifest
+        let abs_dir = if relative_dir.is_absolute() {
+            relative_dir
+        } else {
+            cwd.join(relative_dir)
+        };
+
+        let files_written = write_skill_to_dir(version, &abs_dir)?;
+
+        manifest.upsert(InstalledSkill {
+            owner: owner.to_string(),
+            name: name.to_string(),
+            version: version.version.clone(),
+            registry: options.registry.clone(),
+            checksum: checksum.clone(),
+            installed_to: abs_dir.clone(),
+            installed_at: now.clone(),
+        });
+
+        results.push(InstallResult {
+            target,
+            path: abs_dir,
+            files_written,
+        });
+    }
+
+    Ok(results)
+}
+
+/// Write skill files to a directory, creating it if needed.
+///
+/// Writes SKILL.md and any extra files (scripts/, references/, assets/).
+/// Does NOT write skill.toml, MANIFEST.sha256, or versions.toml.
+/// Returns the list of relative paths written.
+fn write_skill_to_dir(version: &SkillVersion, dir: &Path) -> Result<Vec<String>, InstallError> {
+    std::fs::create_dir_all(dir).map_err(|e| InstallError::CreateDir {
+        path: dir.to_path_buf(),
+        source: e,
+    })?;
+
+    let mut written = Vec::new();
+
+    // Write SKILL.md
+    let skill_md_path = dir.join("SKILL.md");
+    std::fs::write(&skill_md_path, &version.skill_md).map_err(|e| InstallError::WriteFile {
+        path: skill_md_path,
+        source: e,
+    })?;
+    written.push("SKILL.md".to_string());
+
+    // Write extra files (scripts/, references/, assets/)
+    for (rel_path, file) in &version.files {
+        let target_path = dir.join(rel_path);
+
+        // Create subdirectory if needed
+        if let Some(parent) = target_path.parent() {
+            // Only create subdirs that are in the allowed set
+            let subdir = rel_path.split('/').next().unwrap_or("");
+            if !EXTRA_DIRS.contains(&subdir) {
+                continue;
+            }
+            std::fs::create_dir_all(parent).map_err(|e| InstallError::CreateDir {
+                path: parent.to_path_buf(),
+                source: e,
+            })?;
+        }
+
+        std::fs::write(&target_path, &file.content).map_err(|e| InstallError::WriteFile {
+            path: target_path,
+            source: e,
+        })?;
+        written.push(rel_path.clone());
+    }
+
+    written.sort();
+    Ok(written)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::state::{SkillFile, SkillInfo, SkillMetadata};
+
+    fn sample_version() -> SkillVersion {
+        SkillVersion {
+            version: "1.0.0".to_string(),
+            metadata: SkillMetadata {
+                skill: SkillInfo {
+                    name: "test-skill".to_string(),
+                    owner: "testowner".to_string(),
+                    version: "1.0.0".to_string(),
+                    description: "A test skill".to_string(),
+                    trigger: None,
+                    license: None,
+                    author: None,
+                    classification: None,
+                    compatibility: None,
+                },
+            },
+            skill_md: "# Test Skill\n\nDo the thing.".to_string(),
+            skill_toml_raw: "[skill]\nname = \"test-skill\"".to_string(),
+            yanked: false,
+            files: HashMap::new(),
+            published: Some("2026-01-01T00:00:00Z".to_string()),
+            has_content: true,
+            content_hash: None,
+            integrity_ok: None,
+        }
+    }
+
+    fn sample_version_with_files() -> SkillVersion {
+        let mut version = sample_version();
+        version.files.insert(
+            "scripts/lint.sh".to_string(),
+            SkillFile {
+                content: "#!/bin/bash\necho lint".to_string(),
+                mime_type: "text/x-shellscript".to_string(),
+            },
+        );
+        version.files.insert(
+            "references/guide.md".to_string(),
+            SkillFile {
+                content: "# Guide\n\nSome reference.".to_string(),
+                mime_type: "text/markdown".to_string(),
+            },
+        );
+        version
+    }
+
+    #[test]
+    fn test_install_single_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let version = sample_version();
+        let mut manifest = InstalledManifest::default();
+
+        let target_dir = tmp.path().join("project");
+        std::fs::create_dir_all(&target_dir).unwrap();
+
+        // Use the tempdir as working directory by making absolute paths
+        let skill_dir = target_dir.join(".agents/skills/test-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+
+        let files = write_skill_to_dir(&version, &skill_dir).unwrap();
+        assert!(files.contains(&"SKILL.md".to_string()));
+
+        let content = std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+        assert_eq!(content, version.skill_md);
+
+        // Also verify manifest upsert works
+        manifest.upsert(InstalledSkill {
+            owner: "testowner".to_string(),
+            name: "test-skill".to_string(),
+            version: "1.0.0".to_string(),
+            registry: "local:/tmp".to_string(),
+            checksum: integrity::sha256_hex(&version.skill_md),
+            installed_to: skill_dir,
+            installed_at: "2026-01-01T00:00:00Z".to_string(),
+        });
+        assert_eq!(manifest.skills.len(), 1);
+    }
+
+    #[test]
+    fn test_install_with_extra_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let version = sample_version_with_files();
+        let skill_dir = tmp.path().join("skill");
+
+        let files = write_skill_to_dir(&version, &skill_dir).unwrap();
+        assert!(files.contains(&"SKILL.md".to_string()));
+        assert!(files.contains(&"scripts/lint.sh".to_string()));
+        assert!(files.contains(&"references/guide.md".to_string()));
+
+        // Verify files exist
+        assert!(skill_dir.join("SKILL.md").is_file());
+        assert!(skill_dir.join("scripts/lint.sh").is_file());
+        assert!(skill_dir.join("references/guide.md").is_file());
+
+        // Verify content
+        let lint = std::fs::read_to_string(skill_dir.join("scripts/lint.sh")).unwrap();
+        assert_eq!(lint, "#!/bin/bash\necho lint");
+    }
+
+    #[test]
+    fn test_install_to_multiple_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let version = sample_version();
+        let mut manifest = InstalledManifest::default();
+
+        // Install to two different paths (simulating two targets)
+        let dir1 = tmp.path().join("agents/test-skill");
+        let dir2 = tmp.path().join("claude/test-skill");
+
+        write_skill_to_dir(&version, &dir1).unwrap();
+        write_skill_to_dir(&version, &dir2).unwrap();
+
+        manifest.upsert(InstalledSkill {
+            owner: "testowner".to_string(),
+            name: "test-skill".to_string(),
+            version: "1.0.0".to_string(),
+            registry: "local:/tmp".to_string(),
+            checksum: integrity::sha256_hex(&version.skill_md),
+            installed_to: dir1.clone(),
+            installed_at: "2026-01-01T00:00:00Z".to_string(),
+        });
+        manifest.upsert(InstalledSkill {
+            owner: "testowner".to_string(),
+            name: "test-skill".to_string(),
+            version: "1.0.0".to_string(),
+            registry: "local:/tmp".to_string(),
+            checksum: integrity::sha256_hex(&version.skill_md),
+            installed_to: dir2.clone(),
+            installed_at: "2026-01-01T00:00:00Z".to_string(),
+        });
+
+        assert_eq!(manifest.skills.len(), 2);
+        assert!(dir1.join("SKILL.md").is_file());
+        assert!(dir2.join("SKILL.md").is_file());
+    }
+
+    #[test]
+    fn test_reinstall_overwrites() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut version = sample_version();
+        let skill_dir = tmp.path().join("skill");
+
+        // First install
+        write_skill_to_dir(&version, &skill_dir).unwrap();
+        let content1 = std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+
+        // Update and reinstall
+        version.skill_md = "# Updated\n\nNew content.".to_string();
+        version.version = "2.0.0".to_string();
+        write_skill_to_dir(&version, &skill_dir).unwrap();
+        let content2 = std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+
+        assert_ne!(content1, content2);
+        assert_eq!(content2, "# Updated\n\nNew content.");
+    }
+
+    #[test]
+    fn test_manifest_entries_correct() {
+        let tmp = tempfile::tempdir().unwrap();
+        let version = sample_version();
+        let mut manifest = InstalledManifest::default();
+        let skill_dir = tmp.path().join("skill");
+
+        write_skill_to_dir(&version, &skill_dir).unwrap();
+
+        let checksum = integrity::sha256_hex(&version.skill_md);
+        manifest.upsert(InstalledSkill {
+            owner: "testowner".to_string(),
+            name: "test-skill".to_string(),
+            version: "1.0.0".to_string(),
+            registry: "https://github.com/owner/repo.git".to_string(),
+            checksum: checksum.clone(),
+            installed_to: skill_dir,
+            installed_at: "2026-01-01T00:00:00Z".to_string(),
+        });
+
+        let entry = &manifest.skills[0];
+        assert_eq!(entry.owner, "testowner");
+        assert_eq!(entry.name, "test-skill");
+        assert_eq!(entry.version, "1.0.0");
+        assert_eq!(entry.checksum, checksum);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,12 @@
 //! adds the CLI (clap) and MCP server (tower-mcp) on top.
 
 pub mod bm25;
+pub mod config;
 pub mod git;
 pub mod index;
+pub mod install;
 pub mod integrity;
+pub mod manifest;
 pub mod pack;
 pub mod publish;
 pub mod registry;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,371 @@
+//! Installation manifest: tracks which skills are installed and where.
+//!
+//! The manifest lives at `~/.config/skillet/installed.toml` and records
+//! every (skill, target) installation with version, checksum, and path.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config;
+use crate::integrity;
+
+/// Errors that can occur when working with the installation manifest.
+#[derive(Debug, thiserror::Error)]
+pub enum ManifestError {
+    #[error("failed to read manifest at {path}: {source}")]
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to parse manifest at {path}: {source}")]
+    Parse {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+    #[error("failed to write manifest to {path}: {source}")]
+    Write {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to serialize manifest: {0}")]
+    Serialize(#[from] toml::ser::Error),
+    #[error("failed to create directory {path}: {source}")]
+    CreateDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+/// The installation manifest file.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct InstalledManifest {
+    #[serde(default)]
+    pub skills: Vec<InstalledSkill>,
+}
+
+/// A single installed skill entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstalledSkill {
+    pub owner: String,
+    pub name: String,
+    pub version: String,
+    pub registry: String,
+    pub checksum: String,
+    pub installed_to: PathBuf,
+    pub installed_at: String,
+}
+
+/// Result of checking an installed skill's integrity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IntegrityStatus {
+    /// SKILL.md exists and checksum matches.
+    Ok,
+    /// SKILL.md exists but checksum differs.
+    Modified,
+    /// SKILL.md is missing from the installed path.
+    Missing,
+}
+
+/// Default manifest file path: `~/.config/skillet/installed.toml`.
+pub fn manifest_path() -> PathBuf {
+    config::config_dir().join("installed.toml")
+}
+
+/// Load the installation manifest, returning empty if the file is absent.
+pub fn load() -> Result<InstalledManifest, ManifestError> {
+    load_from(&manifest_path())
+}
+
+/// Load the installation manifest from a specific path.
+pub fn load_from(path: &Path) -> Result<InstalledManifest, ManifestError> {
+    if !path.is_file() {
+        return Ok(InstalledManifest::default());
+    }
+    let raw = std::fs::read_to_string(path).map_err(|e| ManifestError::Read {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    let manifest: InstalledManifest = toml::from_str(&raw).map_err(|e| ManifestError::Parse {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    Ok(manifest)
+}
+
+/// Save the installation manifest to the default path.
+pub fn save(manifest: &InstalledManifest) -> Result<(), ManifestError> {
+    save_to(manifest, &manifest_path())
+}
+
+/// Save the installation manifest to a specific path.
+pub fn save_to(manifest: &InstalledManifest, path: &Path) -> Result<(), ManifestError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| ManifestError::CreateDir {
+            path: parent.to_path_buf(),
+            source: e,
+        })?;
+    }
+    let content = toml::to_string_pretty(manifest)?;
+    std::fs::write(path, content).map_err(|e| ManifestError::Write {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    Ok(())
+}
+
+impl InstalledManifest {
+    /// Add or replace an entry by `installed_to` path.
+    pub fn upsert(&mut self, skill: InstalledSkill) {
+        if let Some(existing) = self
+            .skills
+            .iter_mut()
+            .find(|s| s.installed_to == skill.installed_to)
+        {
+            *existing = skill;
+        } else {
+            self.skills.push(skill);
+        }
+    }
+
+    /// Remove an entry by owner, name, and installed path. Returns true if found.
+    pub fn remove(&mut self, owner: &str, name: &str, path: &Path) -> bool {
+        let before = self.skills.len();
+        self.skills
+            .retain(|s| !(s.owner == owner && s.name == name && s.installed_to == path));
+        self.skills.len() < before
+    }
+
+    /// Find all installations of a skill by owner and name.
+    pub fn find_by_skill(&self, owner: &str, name: &str) -> Vec<&InstalledSkill> {
+        self.skills
+            .iter()
+            .filter(|s| s.owner == owner && s.name == name)
+            .collect()
+    }
+
+    /// Find an installation by its installed path.
+    pub fn find_by_path(&self, path: &Path) -> Option<&InstalledSkill> {
+        self.skills.iter().find(|s| s.installed_to == path)
+    }
+
+    /// Check the integrity of an installed skill by reading SKILL.md and
+    /// comparing its checksum against the stored value.
+    pub fn check_integrity(entry: &InstalledSkill) -> IntegrityStatus {
+        let skill_md_path = entry.installed_to.join("SKILL.md");
+        let content = match std::fs::read_to_string(&skill_md_path) {
+            Ok(c) => c,
+            Err(_) => return IntegrityStatus::Missing,
+        };
+        let computed = integrity::sha256_hex(&content);
+        if computed == entry.checksum {
+            IntegrityStatus::Ok
+        } else {
+            IntegrityStatus::Modified
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_entry(path: &Path) -> InstalledSkill {
+        InstalledSkill {
+            owner: "testowner".to_string(),
+            name: "testskill".to_string(),
+            version: "1.0.0".to_string(),
+            registry: "https://github.com/owner/repo.git".to_string(),
+            checksum: "sha256:abc123".to_string(),
+            installed_to: path.to_path_buf(),
+            installed_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_load_empty_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nonexistent.toml");
+        let manifest = load_from(&path).unwrap();
+        assert!(manifest.skills.is_empty());
+    }
+
+    #[test]
+    fn test_save_load_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("installed.toml");
+        let install_path = tmp.path().join("skills/test");
+
+        let mut manifest = InstalledManifest::default();
+        manifest.upsert(sample_entry(&install_path));
+
+        save_to(&manifest, &path).unwrap();
+        let loaded = load_from(&path).unwrap();
+        assert_eq!(loaded.skills.len(), 1);
+        assert_eq!(loaded.skills[0].owner, "testowner");
+        assert_eq!(loaded.skills[0].name, "testskill");
+    }
+
+    #[test]
+    fn test_upsert_new_entry() {
+        let mut manifest = InstalledManifest::default();
+        let path = PathBuf::from("/tmp/skills/test");
+        manifest.upsert(sample_entry(&path));
+        assert_eq!(manifest.skills.len(), 1);
+    }
+
+    #[test]
+    fn test_upsert_replaces_same_path() {
+        let mut manifest = InstalledManifest::default();
+        let path = PathBuf::from("/tmp/skills/test");
+
+        manifest.upsert(sample_entry(&path));
+        assert_eq!(manifest.skills[0].version, "1.0.0");
+
+        let mut updated = sample_entry(&path);
+        updated.version = "2.0.0".to_string();
+        manifest.upsert(updated);
+
+        assert_eq!(manifest.skills.len(), 1);
+        assert_eq!(manifest.skills[0].version, "2.0.0");
+    }
+
+    #[test]
+    fn test_upsert_keeps_different_paths() {
+        let mut manifest = InstalledManifest::default();
+        let path1 = PathBuf::from("/tmp/skills/test1");
+        let path2 = PathBuf::from("/tmp/skills/test2");
+
+        manifest.upsert(sample_entry(&path1));
+        manifest.upsert(sample_entry(&path2));
+        assert_eq!(manifest.skills.len(), 2);
+    }
+
+    #[test]
+    fn test_remove_existing() {
+        let mut manifest = InstalledManifest::default();
+        let path = PathBuf::from("/tmp/skills/test");
+        manifest.upsert(sample_entry(&path));
+
+        let removed = manifest.remove("testowner", "testskill", &path);
+        assert!(removed);
+        assert!(manifest.skills.is_empty());
+    }
+
+    #[test]
+    fn test_remove_nonexistent() {
+        let mut manifest = InstalledManifest::default();
+        let path = PathBuf::from("/tmp/skills/test");
+        let removed = manifest.remove("testowner", "testskill", &path);
+        assert!(!removed);
+    }
+
+    #[test]
+    fn test_find_by_skill() {
+        let mut manifest = InstalledManifest::default();
+        let path1 = PathBuf::from("/tmp/agents/skills/test");
+        let path2 = PathBuf::from("/tmp/claude/skills/test");
+
+        manifest.upsert(sample_entry(&path1));
+        manifest.upsert(sample_entry(&path2));
+
+        let found = manifest.find_by_skill("testowner", "testskill");
+        assert_eq!(found.len(), 2);
+
+        let found = manifest.find_by_skill("nobody", "nothing");
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn test_find_by_path() {
+        let mut manifest = InstalledManifest::default();
+        let path = PathBuf::from("/tmp/skills/test");
+        manifest.upsert(sample_entry(&path));
+
+        assert!(manifest.find_by_path(&path).is_some());
+        assert!(
+            manifest
+                .find_by_path(&PathBuf::from("/tmp/other"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_integrity_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+
+        let content = "# My Skill\n\nDo the thing.";
+        std::fs::write(skill_dir.join("SKILL.md"), content).unwrap();
+
+        let entry = InstalledSkill {
+            owner: "test".to_string(),
+            name: "my-skill".to_string(),
+            version: "1.0.0".to_string(),
+            registry: "local:/tmp".to_string(),
+            checksum: integrity::sha256_hex(content),
+            installed_to: skill_dir,
+            installed_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+
+        assert_eq!(
+            InstalledManifest::check_integrity(&entry),
+            IntegrityStatus::Ok
+        );
+    }
+
+    #[test]
+    fn test_integrity_modified() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+
+        std::fs::write(skill_dir.join("SKILL.md"), "modified content").unwrap();
+
+        let entry = InstalledSkill {
+            owner: "test".to_string(),
+            name: "my-skill".to_string(),
+            version: "1.0.0".to_string(),
+            registry: "local:/tmp".to_string(),
+            checksum: integrity::sha256_hex("original content"),
+            installed_to: skill_dir,
+            installed_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+
+        assert_eq!(
+            InstalledManifest::check_integrity(&entry),
+            IntegrityStatus::Modified
+        );
+    }
+
+    #[test]
+    fn test_integrity_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("my-skill");
+        // Don't create the directory or SKILL.md
+
+        let entry = InstalledSkill {
+            owner: "test".to_string(),
+            name: "my-skill".to_string(),
+            version: "1.0.0".to_string(),
+            registry: "local:/tmp".to_string(),
+            checksum: integrity::sha256_hex("content"),
+            installed_to: skill_dir,
+            installed_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+
+        assert_eq!(
+            InstalledManifest::check_integrity(&entry),
+            IntegrityStatus::Missing
+        );
+    }
+
+    #[test]
+    fn test_malformed_manifest_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("installed.toml");
+        std::fs::write(&path, "this is not valid toml {{{").unwrap();
+        assert!(load_from(&path).is_err());
+    }
+}

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use anyhow::Context;
 
+use crate::config;
 use crate::integrity;
 use crate::state::{VersionRecord, VersionsManifest};
 use crate::validate::{self, ValidationResult};
@@ -91,33 +92,7 @@ fn update_versions_toml(dir: &Path, validation: &ValidationResult) -> anyhow::Re
 
 /// Current time as ISO 8601 string (UTC).
 fn now_iso8601() -> String {
-    // Use std::time to avoid adding a chrono dependency
-    let now = std::time::SystemTime::now();
-    let duration = now
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
-    let secs = duration.as_secs();
-
-    // Convert to date-time components manually
-    let days = secs / 86400;
-    let time_of_day = secs % 86400;
-    let hours = time_of_day / 3600;
-    let minutes = (time_of_day % 3600) / 60;
-    let seconds = time_of_day % 60;
-
-    // Civil date from days since epoch (algorithm from Howard Hinnant)
-    let z = days as i64 + 719468;
-    let era = if z >= 0 { z } else { z - 146096 } / 146097;
-    let doe = (z - era * 146097) as u64;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-    let y = yoe as i64 + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-
-    format!("{y:04}-{m:02}-{d:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
+    config::now_iso8601()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Add `src/config.rs`: CLI config file (`~/.config/skillet/config.toml`), `InstallTarget` enum with 6 agent platforms, target resolution (flag > config > default)
- Add `src/manifest.rs`: installation manifest (`~/.config/skillet/installed.toml`) tracking installed skills with version, checksum, path; `thiserror`-based errors
- Add `src/install.rs`: core install logic writing SKILL.md + extra files to target dirs, manifest upsert
- Add `load_registries()` to `src/registry.rs`: reusable registry resolution for CLI subcommands
- Add 4 CLI subcommands: `install`, `search`, `info`, `list`
- Add `thiserror` dependency for structured library errors
- Move `now_iso8601()` to `config.rs` as shared utility

## New subcommands

```
skillet install <owner/name> [--target T] [--global] [--version V] [--registry P] [--remote URL]
skillet search <query> [--category C] [--tag T] [--registry P] [--remote URL]
skillet info <owner/name> [--registry P] [--remote URL]
skillet list [--installed]
```

## Test plan

- [x] 30 new unit tests across config, manifest, and install modules (96 lib total)
- [x] All 8 existing MCP integration tests pass unchanged
- [x] `cargo fmt --check`, `cargo clippy -D warnings`, `cargo doc --no-deps` clean
- [x] Manual smoke test of all 4 subcommands against test-registry

Closes #43