### PR TITLE
feat: add install_skill MCP tool

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -832,6 +832,7 @@ fn build_router(state: Arc<AppState>) -> McpRouter {
     let search_skills = tools::search_skills::build(state.clone());
     let list_categories = tools::list_categories::build(state.clone());
     let list_skills_by_owner = tools::list_skills_by_owner::build(state.clone());
+    let install_skill = tools::install_skill::build(state.clone());
 
     let skill_content = resources::skill_content::build(state.clone());
     let skill_content_versioned = resources::skill_content::build_versioned(state.clone());
@@ -846,7 +847,8 @@ fn build_router(state: Arc<AppState>) -> McpRouter {
              Tools:\n\
              - search_skills: Search for skills by keyword, category, tag, or model\n\
              - list_categories: Browse all skill categories\n\
-             - list_skills_by_owner: List all skills by a publisher\n\n\
+             - list_skills_by_owner: List all skills by a publisher\n\
+             - install_skill: Install a skill to the local filesystem for persistent use\n\n\
              Resources:\n\
              - skillet://skills/{owner}/{name}: Get a skill's SKILL.md content\n\
              - skillet://skills/{owner}/{name}/{version}: Get a specific version\n\
@@ -860,16 +862,18 @@ fn build_router(state: Arc<AppState>) -> McpRouter {
              Using skills:\n\
              - **Inline (default)**: Read the resource and follow the skill's \
              instructions for the current session. No restart needed.\n\
-             - **Install**: Write the SKILL.md content to .claude/skills/<name>.md \
-             (project) or ~/.claude/skills/<name>.md (global) for persistent use \
-             across sessions. Requires a restart to take effect.\n\
-             - **Install and use**: Write the file for persistence AND follow \
+             - **Install**: Use the install_skill tool to write SKILL.md to the \
+             appropriate agent skills directory. Supports multiple targets \
+             (agents, claude, cursor, copilot, windsurf, gemini) and project \
+             or global scope. A restart may be required.\n\
+             - **Install and use**: Install for persistence AND follow \
              the instructions inline for immediate use.\n\n\
              Prefer inline use unless the user asks for installation.",
         )
         .tool(search_skills)
         .tool(list_categories)
         .tool(list_skills_by_owner)
+        .tool(install_skill)
         .resource_template(skill_content)
         .resource_template(skill_content_versioned)
         .resource_template(skill_metadata)
@@ -1218,6 +1222,7 @@ mod tests {
         assert!(names.contains(&"search_skills"));
         assert!(names.contains(&"list_categories"));
         assert!(names.contains(&"list_skills_by_owner"));
+        assert!(names.contains(&"install_skill"));
     }
 
     #[tokio::test]

--- a/src/tools/install_skill.rs
+++ b/src/tools/install_skill.rs
@@ -1,0 +1,156 @@
+//! install_skill tool -- install a skill to the local filesystem
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use skillet_mcp::config::{ALL_TARGETS, InstallTarget};
+use skillet_mcp::install::{self, InstallOptions};
+use skillet_mcp::manifest;
+use skillet_mcp::state::AppState;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct InstallSkillInput {
+    /// Skill owner (e.g. "joshrotenberg")
+    owner: String,
+    /// Skill name (e.g. "rust-dev")
+    name: String,
+    /// Install target: "agents", "claude", "cursor", "copilot", "windsurf", "gemini", or "all"
+    /// (default: "agents")
+    #[serde(default)]
+    target: Option<String>,
+    /// Install globally instead of into the current project (default: false)
+    #[serde(default)]
+    global: Option<bool>,
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("install_skill")
+        .description(
+            "Install a skill to the local filesystem for persistent use. \
+             Writes SKILL.md (and any extra files) to the appropriate agent \
+             skills directory. Use this when the user wants to install a skill \
+             rather than just reading it inline.",
+        )
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<InstallSkillInput>| async move {
+                let index = state.index.read().await;
+
+                // Look up the skill
+                let entry = match index.skills.get(&(input.owner.clone(), input.name.clone())) {
+                    Some(e) => e,
+                    None => {
+                        return Ok(CallToolResult::error(format!(
+                            "Skill '{}/{}' not found in any registry.",
+                            input.owner, input.name
+                        )));
+                    }
+                };
+
+                // Get latest version
+                let version = match entry.latest() {
+                    Some(v) => v,
+                    None => {
+                        return Ok(CallToolResult::error(format!(
+                            "No available versions for '{}/{}' (all yanked).",
+                            input.owner, input.name
+                        )));
+                    }
+                };
+
+                // Resolve target
+                let targets = match resolve_mcp_target(input.target.as_deref()) {
+                    Ok(t) => t,
+                    Err(msg) => return Ok(CallToolResult::error(msg)),
+                };
+
+                let global = input.global.unwrap_or(false);
+
+                // Determine registry identifier from state
+                let registry_id = if let Some(path) = state.registry_paths.first() {
+                    format!("local:{}", path.display())
+                } else {
+                    "unknown".to_string()
+                };
+
+                // Load manifest
+                let mut installed_manifest = match manifest::load() {
+                    Ok(m) => m,
+                    Err(e) => {
+                        return Ok(CallToolResult::error(format!(
+                            "Failed to load installation manifest: {e}"
+                        )));
+                    }
+                };
+
+                let options = InstallOptions {
+                    targets,
+                    global,
+                    registry: registry_id,
+                };
+
+                // Install
+                let results = match install::install_skill(
+                    &input.owner,
+                    &input.name,
+                    version,
+                    &options,
+                    &mut installed_manifest,
+                ) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        return Ok(CallToolResult::error(format!(
+                            "Failed to install skill: {e}"
+                        )));
+                    }
+                };
+
+                // Save manifest
+                if let Err(e) = manifest::save(&installed_manifest) {
+                    return Ok(CallToolResult::error(format!(
+                        "Skill files written but failed to save manifest: {e}"
+                    )));
+                }
+
+                // Build response
+                let scope = if global { "global" } else { "project" };
+                let mut output = format!(
+                    "Installed {}/{} v{} ({scope}):\n\n",
+                    input.owner, input.name, version.version,
+                );
+                for r in &results {
+                    output.push_str(&format!(
+                        "- **{}**: `{}` ({} file{})\n",
+                        r.target,
+                        r.path.display(),
+                        r.files_written.len(),
+                        if r.files_written.len() == 1 { "" } else { "s" },
+                    ));
+                }
+
+                output.push_str(
+                    "\nThe skill is now installed. \
+                     A restart may be required for the agent to pick it up.",
+                );
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}
+
+/// Resolve a target string from MCP input to a list of InstallTargets.
+fn resolve_mcp_target(target: Option<&str>) -> Result<Vec<InstallTarget>, String> {
+    let target_str = target.unwrap_or("agents");
+    match InstallTarget::parse(target_str) {
+        Ok(Some(t)) => Ok(vec![t]),
+        Ok(None) => Ok(ALL_TARGETS.to_vec()),
+        Err(e) => Err(e.to_string()),
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,3 +1,4 @@
+pub mod install_skill;
 pub mod list_categories;
 pub mod list_skills_by_owner;
 pub mod search_skills;


### PR DESCRIPTION
## Summary

- Add `install_skill` MCP tool that lets agents install skills to the local filesystem
- Supports `owner`, `name`, `target` (agents/claude/cursor/copilot/windsurf/gemini/all), and `global` parameters
- Uses the install infrastructure from #44 (config, manifest, install modules)
- Updated MCP server instructions to document the new tool
- Added `install_skill` assertion to `test_mcp_list_tools`

## Test plan

- [x] `cargo fmt --check`, `cargo clippy -D warnings`, `cargo doc --no-deps` clean
- [x] All 104 tests pass (96 lib + 8 binary)
- [x] `test_mcp_list_tools` confirms `install_skill` is registered
- [x] Smoke tested via CLI subcommands in #44

Closes #39