### PR TITLE
docs: rewrite README to reflect CLI + MCP dual nature

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,51 +8,87 @@ AI agent skills (structured prompts that guide agent behavior) are scattered
 across GitHub repos, npm packages, and copy-paste threads. There's no
 standard way to discover or distribute them at runtime.
 
-Skillet is a toolkit for building and serving skill registries. Create your
-own registry, publish skills to it, and serve it to agents over MCP -- or
-use the CLI directly. Skills follow the
+Skillet solves this. Use the CLI to search, install, and manage skills
+from the command line -- or serve registries to agents over MCP. Skills
+follow the
 [Agent Skills specification](https://docs.anthropic.com/en/docs/claude-code/skills)
-and work standalone in `.claude/skills/` or any compatible agent.
+and work with Claude Code, Cursor, Copilot, Windsurf, Gemini CLI, and
+any compatible agent.
 
-Think of it like git: the tool is the thing, registries are distributed.
+Think of it like git: skillet is the tool, registries are distributed.
+Anyone can create a registry (a git repo with a flat directory structure),
+publish skills to it, and share it.
 
 ## Quick start
+
+### Use skills
+
+Search a remote registry and install a skill:
+
+```bash
+# Search for skills
+skillet search rust --remote https://github.com/joshrotenberg/skillet-registry.git
+
+# Show details about a skill
+skillet info joshrotenberg/rust-dev --remote https://github.com/joshrotenberg/skillet-registry.git
+
+# Install into your project (for Claude Code)
+skillet install joshrotenberg/rust-dev --remote https://github.com/joshrotenberg/skillet-registry.git
+
+# Install for a different agent
+skillet install joshrotenberg/rust-dev --target cursor --remote https://github.com/joshrotenberg/skillet-registry.git
+
+# Install for all supported agents at once
+skillet install joshrotenberg/rust-dev --target all --remote https://github.com/joshrotenberg/skillet-registry.git
+
+# List installed skills
+skillet list
+```
+
+Install targets: `claude`, `cursor`, `copilot`, `windsurf`, `gemini`, `all`.
+
+### Create skills
+
+Scaffold a new skill and publish it:
+
+```bash
+# Scaffold a new skillpack
+skillet init-skill myname/my-skill --description "What this skill does" --category development --tags "rust,testing"
+
+# Edit the generated skill.toml and SKILL.md
+$EDITOR myname/my-skill/SKILL.md
+
+# Validate it
+skillet validate myname/my-skill
+
+# Pack it (validate + generate manifest + update version history)
+skillet pack myname/my-skill
+
+# Publish to a registry (pack + open PR)
+skillet publish myname/my-skill --repo joshrotenberg/skillet-registry
+```
 
 ### Create a registry
 
 ```bash
-skillet init-registry my-skills
-cd my-skills
+skillet init-registry my-registry
+cd my-registry
+# Add skills as owner/skill-name/ directories
 ```
 
 This scaffolds a git repo with the right structure. Add skills as
 `owner/skill-name/` directories, each with a `skill.toml` and `SKILL.md`.
 
-### Serve it
+### Serve over MCP
 
-As an MCP server (add to your agent's MCP config):
-
-```json
-{
-  "mcpServers": {
-    "skillet": {
-      "command": "skillet",
-      "args": ["--registry", "/path/to/my-skills"]
-    }
-  }
-}
-```
-
-From a remote git repo:
+Add skillet to your agent's MCP config to give it runtime access to skills:
 
 ```json
 {
   "mcpServers": {
     "skillet": {
       "command": "skillet",
-      "args": [
-        "--remote", "https://github.com/joshrotenberg/skillet-registry.git"
-      ]
+      "args": ["--remote", "https://github.com/joshrotenberg/skillet-registry.git"]
     }
   }
 }
@@ -76,6 +112,17 @@ Combine multiple registries (local and remote, first match wins):
 
 ### What it looks like
 
+**CLI:**
+
+```
+$ skillet search rust --remote https://github.com/joshrotenberg/skillet-registry.git
+
+joshrotenberg/rust-dev    Rust development standards and conventions
+joshrotenberg/rust-ci     Rust CI/CD pipeline setup
+```
+
+**MCP (agent integration):**
+
 ```
 User: Set up a new Rust project with CI
 
@@ -89,11 +136,10 @@ Agent: Let me search for relevant skills.
        I'll follow the rust-dev skill's conventions for project setup...
 ```
 
-## How it works
+## MCP interface
 
-Agents discover skills via MCP tools, fetch content via resource templates,
-and use it inline within their current context. There is no installation
-step -- the skill content goes directly into the agent's working memory.
+When running as an MCP server, agents discover skills via tools and fetch
+content via resource templates.
 
 | Tool / Resource | Purpose |
 |---|---|
@@ -150,25 +196,34 @@ The `SKILL.md` is the prompt itself. It uses minimal YAML frontmatter and
 is fully compatible with the Agent Skills spec -- you can drop it into
 `.claude/skills/` and it works standalone.
 
-## Publishing skills
-
-Skillet provides a three-step pipeline for publishing skills to a registry:
-
-1. `skillet validate <path>` -- check that skill.toml and SKILL.md are valid
-2. `skillet pack <path>` -- validate, generate content manifest, update version history
-3. `skillet publish <path> --repo <owner/repo>` -- pack and open a PR against the registry
-
 ## CLI reference
 
-```
-skillet [serve] [OPTIONS]
-skillet validate <PATH>
-skillet pack <PATH>
-skillet publish <PATH> --repo <OWNER/REPO> [--dry-run]
-skillet init-registry <PATH> [--name <NAME>]
-```
+### Use skills
 
-Server options:
+| Command | Description |
+|---|---|
+| `skillet search <query>` | Search for skills (`*` for all). Supports `--category`, `--tag` filters |
+| `skillet info <owner/name>` | Show detailed information about a skill |
+| `skillet install <owner/name>` | Install a skill. Supports `--target`, `--global`, `--version` |
+| `skillet list` | List installed skills |
+
+### Author skills
+
+| Command | Description |
+|---|---|
+| `skillet init-skill <path>` | Scaffold a new skillpack. Supports `--description`, `--category`, `--tags` |
+| `skillet validate <path>` | Validate a skillpack directory |
+| `skillet pack <path>` | Validate + generate manifest + update version history |
+| `skillet publish <path> --repo <owner/repo>` | Pack + open a PR against the registry. Supports `--dry-run` |
+
+### Manage registries
+
+| Command | Description |
+|---|---|
+| `skillet init-registry <path>` | Scaffold a new registry git repo. Supports `--name` |
+| `skillet [serve]` | Run the MCP server (default when no subcommand is given) |
+
+### Server options
 
 | Flag | Description |
 |---|---|
@@ -193,8 +248,8 @@ Requires Rust 1.90 or later.
 
 ## Status
 
-Working prototype. The skill schema is stable, the MCP interface is
-functional, and there's a
+Working prototype. The skill schema is stable, both the CLI and MCP
+interface are functional, and there's a
 [sample registry](https://github.com/joshrotenberg/skillet-registry)
 with skills across development, devops, and security categories. The
 registry format is flat files, git-backed, with auditable history.


### PR DESCRIPTION
## Summary

- Restructure Quick Start into four paths: **Use skills** (search/install/list), **Create skills** (init-skill/validate/pack/publish), **Create a registry**, and **Serve over MCP**
- Lead with CLI usage instead of MCP config JSON
- Document all new CLI commands: `search`, `install`, `info`, `list`, `init-skill`
- Add CLI reference tables grouped by concern (use, author, manage)
- List multi-agent install targets (claude, cursor, copilot, windsurf, gemini, all)
- Add CLI example alongside the existing MCP agent example
- Rename "How it works" to "MCP interface", scoped to tools/resources table

Closes #51

## Test plan

- [ ] Read through for accuracy against `--help` output
- [ ] All CLI commands documented
- [ ] MCP tools/resources table still present
- [ ] No broken links