### PR TITLE
feat: fall back to official registry when no registries configured

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1038,9 +1038,22 @@ async fn run_serve_inner(args: ServeArgs) -> Result<(), tower_mcp::BoxError> {
         registry_paths.push(path);
     }
 
-    // Default to local test-registry if nothing specified
-    if registry_paths.is_empty() {
-        registry_paths.push(PathBuf::from("test-registry"));
+    // Fall back to the official registry if nothing is configured
+    let mut default_remote_urls = Vec::new();
+    if registry_paths.is_empty() && args.remote.is_empty() {
+        let url = registry::DEFAULT_REGISTRY_URL;
+        let target = cache_dir_for_url(&cache_base, url);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        git::clone_or_pull(url, &target)?;
+        let path = match &args.subdir {
+            Some(sub) => target.join(sub),
+            None => target,
+        };
+        tracing::info!(registry = %path.display(), remote = %url, "Using default registry");
+        registry_paths.push(path);
+        default_remote_urls.push(url.to_string());
     }
 
     tracing::info!(count = registry_paths.len(), "Starting skillet server");
@@ -1059,10 +1072,11 @@ async fn run_serve_inner(args: ServeArgs) -> Result<(), tower_mcp::BoxError> {
     }
 
     let skill_search = search::SkillSearch::build(&merged_index);
-    let remote_urls = args.remote.clone();
+    let mut remote_urls = args.remote.clone();
+    remote_urls.extend(default_remote_urls);
     let state = AppState::new(
         registry_paths,
-        remote_urls,
+        remote_urls.clone(),
         merged_index,
         skill_search,
         config,
@@ -1071,7 +1085,7 @@ async fn run_serve_inner(args: ServeArgs) -> Result<(), tower_mcp::BoxError> {
     // Spawn background refresh tasks for each remote
     let interval = parse_duration(&args.refresh_interval)?;
     if interval > Duration::ZERO {
-        for url in args.remote {
+        for url in remote_urls {
             spawn_refresh_task(Arc::clone(&state), url, interval);
         }
     }


### PR DESCRIPTION
## Summary

- Adds `DEFAULT_REGISTRY_URL` constant pointing to the official skillet-registry
- `load_registries()` (used by CLI commands) falls back to the default instead of erroring when no registries are configured
- MCP serve path falls back to the default registry instead of `test-registry`, including for background refresh tasks
- Zero-config experience: `skillet search rust` works out of the box

## Changes

| File | Change |
|------|--------|
| `src/registry.rs` | Add `DEFAULT_REGISTRY_URL`, replace error bail with fallback in `load_registries()` |
| `src/main.rs` | Replace `test-registry` fallback with official registry clone, include default in refresh tasks |

## Test plan

- [x] All 125 tests pass (117 lib + 8 binary)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] Manual: run `skillet search rust` with no config -- should use default registry
- [ ] Manual: run MCP server with no flags -- should clone and serve default registry

Closes #65