### PR TITLE
feat: extend registry config.toml with richer metadata

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -53,8 +53,12 @@ impl Default for RegistryConfig {
             registry: RegistryInfo {
                 name: default_registry_name(),
                 version: default_registry_version(),
+                description: None,
+                maintainer: None,
                 urls: None,
                 auth: None,
+                suggests: None,
+                defaults: None,
             },
         }
     }
@@ -69,9 +73,38 @@ pub struct RegistryInfo {
     #[serde(default = "default_registry_version")]
     pub version: u32,
     #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub maintainer: Option<RegistryMaintainer>,
+    #[serde(default)]
     pub urls: Option<RegistryUrls>,
     #[serde(default)]
     pub auth: Option<RegistryAuth>,
+    #[serde(default)]
+    pub suggests: Option<Vec<RegistrySuggestion>>,
+    #[serde(default)]
+    pub defaults: Option<RegistryDefaults>,
+}
+
+/// Registry maintainer information.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RegistryMaintainer {
+    pub name: Option<String>,
+    pub github: Option<String>,
+    pub email: Option<String>,
+}
+
+/// A suggested registry for discovery (lightweight federation).
+#[derive(Debug, Clone, Deserialize)]
+pub struct RegistrySuggestion {
+    pub url: String,
+    pub description: Option<String>,
+}
+
+/// Server defaults that a registry can specify.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RegistryDefaults {
+    pub refresh_interval: Option<String>,
 }
 
 /// Optional URL endpoints for non-git-backed registries.

--- a/test-registry/config.toml
+++ b/test-registry/config.toml
@@ -1,3 +1,15 @@
 [registry]
 name = "skillet"
 version = 1
+description = "Test registry for skillet development"
+
+[registry.maintainer]
+name = "Josh Rotenberg"
+github = "joshrotenberg"
+
+[[registry.suggests]]
+url = "https://github.com/joshrotenberg/skillet-registry.git"
+description = "Official community skills"
+
+[registry.defaults]
+refresh_interval = "10m"


### PR DESCRIPTION
## Summary

- Add optional `description`, `maintainer`, `suggests`, and `defaults` fields to registry `config.toml`
- All new fields use `#[serde(default)]` so existing registries continue to work unchanged
- `init-registry` auto-populates `[registry.maintainer]` from git global config and accepts `--description`
- MCP server uses `defaults.refresh_interval` from registry config as fallback when CLI flag is at default

## Test plan

- [x] Parse config with all new fields
- [x] Parse config with partial new fields (description only)
- [x] Parse minimal old-style config (backward compat)
- [x] Default config when absent has all new fields as `None`
- [x] `init-registry --description` generates correct config
- [x] Test registry config updated with example fields, all existing tests pass
- [x] `cargo fmt`, `clippy`, all 145 tests pass

Closes #59