### PR TITLE
feat: add info_skill MCP tool

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1492,7 +1492,7 @@ fn print_safety_report(report: &safety::SafetyReport) {
 }
 
 /// All known tool short names.
-const ALL_TOOL_NAMES: &[&str] = &["search", "categories", "owner", "install"];
+const ALL_TOOL_NAMES: &[&str] = &["search", "categories", "owner", "install", "info"];
 
 /// All known resource short names.
 const ALL_RESOURCE_NAMES: &[&str] = &["skills", "metadata", "files"];
@@ -1552,6 +1552,9 @@ fn build_router(state: Arc<AppState>, caps: &ServerCapabilities) -> McpRouter {
     if caps.tools.contains("install") {
         router = router.tool(tools::install_skill::build(state.clone()));
     }
+    if caps.tools.contains("info") {
+        router = router.tool(tools::info_skill::build(state.clone()));
+    }
 
     // Register resources conditionally
     if caps.resources.contains("skills") {
@@ -1592,6 +1595,11 @@ fn build_instructions(caps: &ServerCapabilities) -> String {
     if caps.tools.contains("install") {
         tool_lines
             .push("- install_skill: Install a skill to the local filesystem for persistent use");
+    }
+    if caps.tools.contains("info") {
+        tool_lines.push(
+            "- info_skill: Get detailed information about a specific skill (version, author, tags, files, etc.)",
+        );
     }
     if !tool_lines.is_empty() {
         text.push_str("Tools:\n");

--- a/src/tools/info_skill.rs
+++ b/src/tools/info_skill.rs
@@ -1,0 +1,151 @@
+//! info_skill tool -- get detailed information about a specific skill
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use skillet_mcp::state::AppState;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct InfoSkillInput {
+    /// Skill owner (e.g. "joshrotenberg")
+    owner: String,
+    /// Skill name (e.g. "rust-dev")
+    name: String,
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("info_skill")
+        .description(
+            "Get detailed information about a specific skill including version, \
+             description, author, categories, tags, files, and version history.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<InfoSkillInput>| async move {
+                let index = state.index.read().await;
+
+                let entry = match index.skills.get(&(input.owner.clone(), input.name.clone())) {
+                    Some(e) => e,
+                    None => {
+                        return Ok(CallToolResult::error(format!(
+                            "Skill '{}/{}' not found in any registry.",
+                            input.owner, input.name
+                        )));
+                    }
+                };
+
+                let latest = match entry.latest() {
+                    Some(v) => v,
+                    None => {
+                        return Ok(CallToolResult::error(format!(
+                            "No available versions for '{}/{}' (all yanked).",
+                            input.owner, input.name
+                        )));
+                    }
+                };
+
+                let info = &latest.metadata.skill;
+                let mut output = format!("## {}/{}\n\n", input.owner, input.name);
+
+                output.push_str(&format!("**Version:** {}\n", info.version));
+                output.push_str(&format!("**Description:** {}\n", info.description));
+
+                if let Some(ref trigger) = info.trigger {
+                    output.push_str(&format!("**Trigger:** {trigger}\n"));
+                }
+                if let Some(ref license) = info.license {
+                    output.push_str(&format!("**License:** {license}\n"));
+                }
+                if let Some(ref author) = info.author {
+                    if let Some(ref name) = author.name {
+                        output.push_str(&format!("**Author:** {name}\n"));
+                    }
+                    if let Some(ref github) = author.github {
+                        output.push_str(&format!("**GitHub:** {github}\n"));
+                    }
+                }
+                if let Some(ref classification) = info.classification {
+                    if !classification.categories.is_empty() {
+                        output.push_str(&format!(
+                            "**Categories:** {}\n",
+                            classification.categories.join(", ")
+                        ));
+                    }
+                    if !classification.tags.is_empty() {
+                        output.push_str(&format!("**Tags:** {}\n", classification.tags.join(", ")));
+                    }
+                }
+                if let Some(ref compat) = info.compatibility
+                    && !compat.verified_with.is_empty()
+                {
+                    output.push_str(&format!(
+                        "**Verified with:** {}\n",
+                        compat.verified_with.join(", ")
+                    ));
+                }
+
+                // Extra files
+                if !latest.files.is_empty() {
+                    let mut file_paths: Vec<&String> = latest.files.keys().collect();
+                    file_paths.sort();
+                    output.push_str(&format!(
+                        "**Files:** {}\n",
+                        file_paths
+                            .iter()
+                            .map(|s| s.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ));
+                }
+
+                // Published timestamp
+                if let Some(ref published) = latest.published {
+                    output.push_str(&format!("**Published:** {published}\n"));
+                }
+
+                // Content hash
+                if let Some(ref hash) = latest.content_hash {
+                    let display = if hash.len() > 17 {
+                        format!("{}...", &hash[..17])
+                    } else {
+                        hash.clone()
+                    };
+                    output.push_str(&format!("**Content hash:** {display}\n"));
+                }
+
+                // Integrity
+                match latest.integrity_ok {
+                    Some(true) => output.push_str("**Integrity:** verified\n"),
+                    Some(false) => output.push_str("**Integrity:** MISMATCH\n"),
+                    None => {}
+                }
+
+                // Version history
+                let available: Vec<&str> = entry
+                    .versions
+                    .iter()
+                    .filter(|v| !v.yanked)
+                    .map(|v| v.version.as_str())
+                    .collect();
+                if available.len() > 1 {
+                    output.push_str(&format!("**Versions:** {}\n", available.join(", ")));
+                }
+
+                // Source label for local skills
+                if let Some(label) = entry.source.label() {
+                    output.push_str(&format!("**Source:** {label}\n"));
+                }
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,3 +1,4 @@
+pub mod info_skill;
 pub mod install_skill;
 pub mod list_categories;
 pub mod list_skills_by_owner;


### PR DESCRIPTION
## Summary

- Adds `info_skill` MCP tool that returns detailed information about a specific skill, mirroring the CLI `info` subcommand
- Accepts `owner` and `name` parameters, returns markdown-formatted detail including version, description, trigger, license, author, categories, tags, verified models, files, published date, content hash, integrity status, version history, and source label
- Registered as `"info"` in `ServerCapabilities`, available in read-only mode

Closes #80

## Test plan

- [x] All 223 existing tests pass (198 lib + 25 binary)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] `cargo doc` builds
- [ ] Manual: run `skillet serve`, call `info_skill` with a known skill via MCP client