### PR TITLE
test: CLI scenario tests with assert_cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert_cmd"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +98,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -164,6 +185,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -256,6 +288,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +340,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "libredox",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -738,6 +785,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "notify"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +837,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -846,6 +908,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1181,9 +1273,11 @@ name = "skillet-mcp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "hex",
  "notify-debouncer-mini",
+ "predicates",
  "regex",
  "schemars",
  "serde",
@@ -1255,6 +1349,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -1577,6 +1677,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ thiserror = "2"
 tempfile = "3.26.0"
 regex = "1"
 
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,438 @@
+//! CLI integration tests using assert_cmd.
+//!
+//! All tests use `--registry test-registry` to point at the in-repo fixture.
+//! Tests that write to disk use tempfile for isolation and override `$HOME`
+//! so config/manifest paths don't touch the real filesystem.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::PathBuf;
+
+fn test_registry() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test-registry")
+}
+
+#[allow(deprecated)] // cargo_bin_cmd! macro has compile-time issues; cargo_bin works fine
+fn skillet() -> Command {
+    Command::cargo_bin("skillet").expect("binary exists")
+}
+
+// ── Search and discovery ─────────────────────────────────────────────
+
+#[test]
+fn search_by_keyword() {
+    skillet()
+        .args(["search", "rust", "--registry"])
+        .arg(test_registry())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("rust-dev"));
+}
+
+#[test]
+fn search_wildcard_lists_all() {
+    skillet()
+        .args(["search", "*", "--registry"])
+        .arg(test_registry())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Found"));
+}
+
+#[test]
+fn search_owner_filter() {
+    skillet()
+        .args(["search", "*", "--owner", "joshrotenberg", "--registry"])
+        .arg(test_registry())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("joshrotenberg/rust-dev")
+                .and(predicate::str::contains("acme/").not()),
+        );
+}
+
+#[test]
+fn search_category_filter() {
+    skillet()
+        .args(["search", "*", "--category", "security", "--registry"])
+        .arg(test_registry())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("security-audit")
+                .and(predicate::str::contains("python-dev").not()),
+        );
+}
+
+#[test]
+fn search_tag_filter() {
+    skillet()
+        .args(["search", "*", "--tag", "pytest", "--registry"])
+        .arg(test_registry())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("python-dev"));
+}
+
+#[test]
+fn search_no_results() {
+    skillet()
+        .args(["search", "nonexistent_xyzzy_skill", "--registry"])
+        .arg(test_registry())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No skills found"));
+}
+
+#[test]
+fn categories_lists_with_counts() {
+    skillet()
+        .args(["categories", "--registry"])
+        .arg(test_registry())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("development").and(predicate::str::contains("categor")));
+}
+
+// ── Info ─────────────────────────────────────────────────────────────
+
+#[test]
+fn info_shows_skill_details() {
+    skillet()
+        .args(["info", "joshrotenberg/rust-dev", "--registry"])
+        .arg(test_registry())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("joshrotenberg/rust-dev")
+                .and(predicate::str::contains("version"))
+                .and(predicate::str::contains("description"))
+                .and(predicate::str::contains("Rust")),
+        );
+}
+
+#[test]
+fn info_not_found() {
+    skillet()
+        .args(["info", "nonexistent/skill", "--registry"])
+        .arg(test_registry())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found"));
+}
+
+// ── Install and list ─────────────────────────────────────────────────
+
+#[test]
+fn install_writes_files() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let home = tmp.path().join("home");
+    std::fs::create_dir_all(&home).expect("create home");
+
+    skillet()
+        .args(["install", "joshrotenberg/rust-dev", "--registry"])
+        .arg(test_registry())
+        .args(["--target", "agents"])
+        .env("HOME", &home)
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Installed joshrotenberg/rust-dev"));
+
+    // Verify the SKILL.md was written
+    let skill_md = tmp.path().join(".agents/skills/rust-dev/SKILL.md");
+    assert!(
+        skill_md.exists(),
+        "SKILL.md should be written at {}",
+        skill_md.display()
+    );
+}
+
+#[test]
+fn list_shows_installed_skill() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let home = tmp.path().join("home");
+    std::fs::create_dir_all(&home).expect("create home");
+
+    // Install first
+    skillet()
+        .args(["install", "joshrotenberg/rust-dev", "--registry"])
+        .arg(test_registry())
+        .args(["--target", "agents"])
+        .env("HOME", &home)
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // List should show it
+    skillet()
+        .args(["list"])
+        .env("HOME", &home)
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("joshrotenberg/rust-dev")
+                .and(predicate::str::contains("installed")),
+        );
+}
+
+#[test]
+fn list_empty_when_nothing_installed() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let home = tmp.path().join("home");
+    std::fs::create_dir_all(&home).expect("create home");
+
+    skillet()
+        .args(["list"])
+        .env("HOME", &home)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No skills installed"));
+}
+
+#[test]
+fn install_not_found() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let home = tmp.path().join("home");
+    std::fs::create_dir_all(&home).expect("create home");
+
+    skillet()
+        .args(["install", "nonexistent/skill", "--registry"])
+        .arg(test_registry())
+        .env("HOME", &home)
+        .current_dir(tmp.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found"));
+}
+
+// ── Authoring: init-skill ────────────────────────────────────────────
+
+#[test]
+fn init_skill_creates_files() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let skill_path = tmp.path().join("test-owner/test-skill");
+
+    skillet()
+        .args(["init-skill"])
+        .arg(&skill_path)
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Created skillpack")
+                .and(predicate::str::contains("test-owner"))
+                .and(predicate::str::contains("test-skill")),
+        );
+
+    assert!(
+        skill_path.join("skill.toml").exists(),
+        "skill.toml should exist"
+    );
+    assert!(
+        skill_path.join("SKILL.md").exists(),
+        "SKILL.md should exist"
+    );
+}
+
+#[test]
+fn init_skill_with_options() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let skill_path = tmp.path().join("myowner/my-skill");
+
+    skillet()
+        .args(["init-skill"])
+        .arg(&skill_path)
+        .args([
+            "--description",
+            "A great skill",
+            "--category",
+            "development",
+            "--tags",
+            "rust,testing",
+        ])
+        .assert()
+        .success();
+
+    let toml_content =
+        std::fs::read_to_string(skill_path.join("skill.toml")).expect("read skill.toml");
+    assert!(
+        toml_content.contains("A great skill"),
+        "should contain description: {toml_content}"
+    );
+    assert!(
+        toml_content.contains("development"),
+        "should contain category: {toml_content}"
+    );
+    assert!(
+        toml_content.contains("rust"),
+        "should contain tag: {toml_content}"
+    );
+}
+
+// ── Authoring: validate ──────────────────────────────────────────────
+
+#[test]
+fn validate_clean_skill() {
+    skillet()
+        .args(["validate"])
+        .arg(test_registry().join("joshrotenberg/rust-dev"))
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Validation passed")
+                .and(predicate::str::contains("skill.toml"))
+                .and(predicate::str::contains("SKILL.md")),
+        );
+}
+
+#[test]
+fn validate_unsafe_skill_exits_2() {
+    skillet()
+        .args(["validate"])
+        .arg(test_registry().join("acme/unsafe-demo"))
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("Safety scan"))
+        .stderr(predicate::str::contains("safety issues detected"));
+}
+
+#[test]
+fn validate_unsafe_skill_skip_safety() {
+    skillet()
+        .args(["validate", "--skip-safety"])
+        .arg(test_registry().join("acme/unsafe-demo"))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Validation passed"));
+}
+
+#[test]
+fn validate_nonexistent_path() {
+    skillet()
+        .args(["validate", "/tmp/nonexistent-skill-path-xyzzy"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error").or(predicate::str::contains("failed")));
+}
+
+// ── Authoring: pack ──────────────────────────────────────────────────
+
+#[test]
+fn pack_creates_manifest_and_versions() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let skill_path = tmp.path().join("myowner/my-skill");
+
+    // Scaffold a skill first
+    skillet()
+        .args(["init-skill"])
+        .arg(&skill_path)
+        .assert()
+        .success();
+
+    // Pack it
+    skillet()
+        .args(["pack"])
+        .arg(&skill_path)
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Pack succeeded")
+                .and(predicate::str::contains("MANIFEST.sha256"))
+                .and(predicate::str::contains("versions.toml")),
+        );
+
+    assert!(
+        skill_path.join("MANIFEST.sha256").exists(),
+        "MANIFEST.sha256 should be created"
+    );
+    assert!(
+        skill_path.join("versions.toml").exists(),
+        "versions.toml should be created"
+    );
+}
+
+#[test]
+fn pack_unsafe_skill_exits_2() {
+    // Copy unsafe-demo to a temp dir so pack doesn't modify the fixture
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let src = test_registry().join("acme/unsafe-demo");
+    let dst = tmp.path().join("acme/unsafe-demo");
+    std::fs::create_dir_all(&dst).expect("create dirs");
+    for entry in std::fs::read_dir(&src).expect("read src") {
+        let entry = entry.expect("dir entry");
+        if entry.file_type().expect("file type").is_file() {
+            std::fs::copy(entry.path(), dst.join(entry.file_name())).expect("copy");
+        }
+    }
+
+    skillet()
+        .args(["pack"])
+        .arg(&dst)
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("Safety scan"))
+        .stderr(predicate::str::contains("safety issues detected"));
+}
+
+// ── Authoring: init-registry ─────────────────────────────────────────
+
+#[test]
+fn init_registry_creates_files() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let registry_path = tmp.path().join("my-registry");
+
+    skillet()
+        .args(["init-registry"])
+        .arg(&registry_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Initialized skill registry"));
+
+    assert!(
+        registry_path.join("config.toml").exists(),
+        "config.toml should be created"
+    );
+    assert!(
+        registry_path.join(".gitignore").exists(),
+        ".gitignore should be created"
+    );
+}
+
+#[test]
+fn init_registry_with_options() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let registry_path = tmp.path().join("named-registry");
+
+    skillet()
+        .args(["init-registry"])
+        .arg(&registry_path)
+        .args(["--name", "My Registry", "--description", "A test registry"])
+        .assert()
+        .success();
+
+    let config =
+        std::fs::read_to_string(registry_path.join("config.toml")).expect("read config.toml");
+    assert!(
+        config.contains("My Registry"),
+        "should contain registry name: {config}"
+    );
+    assert!(
+        config.contains("A test registry"),
+        "should contain description: {config}"
+    );
+}
+
+#[test]
+fn init_registry_fails_on_existing_dir() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+
+    // The temp dir itself already exists
+    skillet()
+        .args(["init-registry"])
+        .arg(tmp.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already exists"));
+}


### PR DESCRIPTION
## Summary

Closes #91

Add 24 CLI integration tests using `assert_cmd` and `predicates` crates, exercising all major subcommands end-to-end against the test-registry fixture.

**Search and discovery (7):** keyword search, wildcard, owner/category/tag filters, no results, categories with counts

**Info (2):** skill details, not found error

**Install and list (4):** install writes files to disk, list shows installed skill, empty list, not found error

**Authoring (8):** init-skill creates files + with options, validate clean/unsafe/skip-safety/nonexistent, pack creates manifest+versions, pack unsafe exits 2

**Registry (3):** init-registry creates files + with options, fails on existing dir

Tests override `$HOME` with `tempfile` for install/list isolation so nothing touches the real filesystem.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (198 lib + 35 bin + 24 cli = 257 total)