### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.2.0] - 2026-02-27
+
+### Bug Fixes
+
+- Add --version flag and fix commit signing in git commands (#114, #118) ([#119](https://github.com/joshrotenberg/skillet/pull/119))
+
+### Documentation
+
+- Overhaul README for public launch ([#89](https://github.com/joshrotenberg/skillet/pull/89)) ([#101](https://github.com/joshrotenberg/skillet/pull/101))
+- Add install options and lead with MCP quick start ([#102](https://github.com/joshrotenberg/skillet/pull/102))
+- Add Docker MCP config example to quick start ([#109](https://github.com/joshrotenberg/skillet/pull/109))
+- Add RELEASING.md and document HTTP transport security (#111, #116) ([#121](https://github.com/joshrotenberg/skillet/pull/121))
+
+### Features
+
+- Add `skillet setup` command ([#64](https://github.com/joshrotenberg/skillet/pull/64)) ([#100](https://github.com/joshrotenberg/skillet/pull/100))
+- Add list_installed, audit_skills, setup_config, validate_skill MCP tools ([#108](https://github.com/joshrotenberg/skillet/pull/108))
+- Add --require-trusted flag and improve trust warnings (#112, #117) ([#120](https://github.com/joshrotenberg/skillet/pull/120))
+
+### Refactor
+
+- Consolidate error handling across library modules ([#115](https://github.com/joshrotenberg/skillet/pull/115)) ([#123](https://github.com/joshrotenberg/skillet/pull/123))
+- Split main.rs into cli/ module tree ([#113](https://github.com/joshrotenberg/skillet/pull/113)) ([#122](https://github.com/joshrotenberg/skillet/pull/122))
+
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "skillet-mcp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillet-mcp"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.90"
 description = "MCP-native skill registry for AI agents"


### PR DESCRIPTION



## 🤖 New release

* `skillet-mcp`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `skillet-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field TrustConfig.require_trusted in /tmp/.tmpF0E8HE/skillet/src/config.rs:77

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:ManifestFormatError in /tmp/.tmpF0E8HE/skillet/src/error.rs:83
  variant Error:ManifestMissingComposite in /tmp/.tmpF0E8HE/skillet/src/error.rs:85
  variant Error:Scaffold in /tmp/.tmpF0E8HE/skillet/src/error.rs:89
  variant Error:Git in /tmp/.tmpF0E8HE/skillet/src/error.rs:93
  variant Error:InvalidDuration in /tmp/.tmpF0E8HE/skillet/src/error.rs:97
  variant Error:Validation in /tmp/.tmpF0E8HE/skillet/src/error.rs:101
  variant Error:SkillLoad in /tmp/.tmpF0E8HE/skillet/src/error.rs:105
  variant Error:TomlParse in /tmp/.tmpF0E8HE/skillet/src/error.rs:107
  variant Error:FileRead in /tmp/.tmpF0E8HE/skillet/src/error.rs:112
  variant Error:Publish in /tmp/.tmpF0E8HE/skillet/src/error.rs:119
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0] - 2026-02-27

### Bug Fixes

- Add --version flag and fix commit signing in git commands (#114, #118) ([#119](https://github.com/joshrotenberg/skillet/pull/119))

### Documentation

- Overhaul README for public launch ([#89](https://github.com/joshrotenberg/skillet/pull/89)) ([#101](https://github.com/joshrotenberg/skillet/pull/101))
- Add install options and lead with MCP quick start ([#102](https://github.com/joshrotenberg/skillet/pull/102))
- Add Docker MCP config example to quick start ([#109](https://github.com/joshrotenberg/skillet/pull/109))
- Add RELEASING.md and document HTTP transport security (#111, #116) ([#121](https://github.com/joshrotenberg/skillet/pull/121))

### Features

- Add `skillet setup` command ([#64](https://github.com/joshrotenberg/skillet/pull/64)) ([#100](https://github.com/joshrotenberg/skillet/pull/100))
- Add list_installed, audit_skills, setup_config, validate_skill MCP tools ([#108](https://github.com/joshrotenberg/skillet/pull/108))
- Add --require-trusted flag and improve trust warnings (#112, #117) ([#120](https://github.com/joshrotenberg/skillet/pull/120))

### Refactor

- Consolidate error handling across library modules ([#115](https://github.com/joshrotenberg/skillet/pull/115)) ([#123](https://github.com/joshrotenberg/skillet/pull/123))
- Split main.rs into cli/ module tree ([#113](https://github.com/joshrotenberg/skillet/pull/113)) ([#122](https://github.com/joshrotenberg/skillet/pull/122))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).