### PR TITLE
feat: add MCP tools for list_installed, audit, setup, validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,10 @@ fetch content via resource templates.
 | `compare_skills` | Side-by-side comparison of two or more skills |
 | `skill_status` | Check install status and trust tier for a skill |
 | `install_skill` | Install a skill to the local filesystem |
+| `list_installed` | List all skills installed on the local filesystem |
+| `audit_skills` | Verify installed skills against pinned content hashes |
+| `setup_config` | Generate initial configuration at `~/.config/skillet/config.toml` |
+| `validate_skill` | Validate a skillpack directory for correctness and safety |
 
 ### Resources
 

--- a/src/tools/audit_skills.rs
+++ b/src/tools/audit_skills.rs
@@ -1,0 +1,108 @@
+//! audit_skills tool -- verify installed skills against pinned content hashes
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use skillet_mcp::manifest;
+use skillet_mcp::state::AppState;
+use skillet_mcp::trust;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AuditSkillsInput {
+    /// Optional owner to audit (e.g. "joshrotenberg"). Audits all if omitted.
+    #[serde(default)]
+    owner: Option<String>,
+    /// Optional skill name to audit (e.g. "rust-dev"). Requires owner.
+    #[serde(default)]
+    name: Option<String>,
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("audit_skills")
+        .description(
+            "Audit installed skills against pinned content hashes. \
+             Checks that installed skill files haven't been modified since \
+             installation. Returns per-skill status: OK, MODIFIED, MISSING, \
+             or UNPINNED.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state,
+            |State(_state): State<Arc<AppState>>, Json(input): Json<AuditSkillsInput>| async move {
+                let installed = match manifest::load() {
+                    Ok(m) => m,
+                    Err(e) => {
+                        return Ok(CallToolResult::error(format!(
+                            "Failed to load installation manifest: {e}"
+                        )));
+                    }
+                };
+
+                let trust_state = match trust::load() {
+                    Ok(s) => s,
+                    Err(e) => {
+                        return Ok(CallToolResult::error(format!(
+                            "Failed to load trust state: {e}"
+                        )));
+                    }
+                };
+
+                let results = trust::audit(
+                    &installed,
+                    &trust_state,
+                    input.owner.as_deref(),
+                    input.name.as_deref(),
+                );
+
+                if results.is_empty() {
+                    return Ok(CallToolResult::text(
+                        "No installed skills to audit.\n\n\
+                         Install skills with install_skill, then audit to verify integrity.",
+                    ));
+                }
+
+                let mut output = format!(
+                    "## Audit Results ({} skill{})\n\n",
+                    results.len(),
+                    if results.len() == 1 { "" } else { "s" }
+                );
+
+                let mut has_problems = false;
+                for r in &results {
+                    if matches!(
+                        r.status,
+                        trust::AuditStatus::Modified | trust::AuditStatus::Missing
+                    ) {
+                        has_problems = true;
+                    }
+                    output.push_str(&format!(
+                        "- **[{}]** {}/{} v{} -> `{}`\n",
+                        r.status,
+                        r.owner,
+                        r.name,
+                        r.version,
+                        r.installed_to.display(),
+                    ));
+                }
+
+                if has_problems {
+                    output.push_str(
+                        "\nSome skills have integrity issues. Consider re-installing \
+                         affected skills or investigating the changes.",
+                    );
+                } else {
+                    output.push_str("\nAll audited skills passed integrity checks.");
+                }
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}

--- a/src/tools/list_installed.rs
+++ b/src/tools/list_installed.rs
@@ -1,0 +1,99 @@
+//! list_installed tool -- list all installed skills
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use skillet_mcp::manifest;
+use skillet_mcp::state::AppState;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListInstalledInput {
+    /// Optional owner filter (e.g. "joshrotenberg")
+    #[serde(default)]
+    owner: Option<String>,
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("list_installed")
+        .description(
+            "List all skills currently installed on the local filesystem. \
+             Shows skill name, version, install target, path, and timestamp. \
+             Use this to see what skills are available before searching for more.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state,
+            |State(_state): State<Arc<AppState>>, Json(input): Json<ListInstalledInput>| async move {
+                let installed = manifest::load().unwrap_or_default();
+
+                let skills: Vec<&manifest::InstalledSkill> = installed
+                    .skills
+                    .iter()
+                    .filter(|s| {
+                        if let Some(ref owner) = input.owner
+                            && s.owner != *owner
+                        {
+                            return false;
+                        }
+                        true
+                    })
+                    .collect();
+
+                if skills.is_empty() {
+                    let msg = if let Some(ref owner) = input.owner {
+                        format!(
+                            "No installed skills from '{owner}'.\n\n\
+                             Use search_skills to discover skills to install."
+                        )
+                    } else {
+                        "No skills installed.\n\n\
+                         Use search_skills to discover skills, then install_skill to install them."
+                            .to_string()
+                    };
+                    return Ok(CallToolResult::text(msg));
+                }
+
+                // Group by (owner, name) for cleaner output
+                let mut grouped: BTreeMap<(String, String), Vec<&manifest::InstalledSkill>> =
+                    BTreeMap::new();
+                for skill in &skills {
+                    grouped
+                        .entry((skill.owner.clone(), skill.name.clone()))
+                        .or_default()
+                        .push(skill);
+                }
+
+                let mut output = format!(
+                    "## Installed Skills ({} skill{}, {} target{})\n\n",
+                    grouped.len(),
+                    if grouped.len() == 1 { "" } else { "s" },
+                    skills.len(),
+                    if skills.len() == 1 { "" } else { "s" },
+                );
+
+                for ((owner, name), entries) in &grouped {
+                    let version = &entries[0].version;
+                    output.push_str(&format!("**{owner}/{name}** v{version}\n"));
+                    for entry in entries {
+                        output.push_str(&format!(
+                            "  - `{}` (installed {})\n",
+                            entry.installed_to.display(),
+                            entry.installed_at,
+                        ));
+                    }
+                    output.push('\n');
+                }
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,7 +1,11 @@
+pub mod audit_skills;
 pub mod compare_skills;
 pub mod info_skill;
 pub mod install_skill;
 pub mod list_categories;
+pub mod list_installed;
 pub mod list_skills_by_owner;
 pub mod search_skills;
+pub mod setup_config;
 pub mod skill_status;
+pub mod validate_skill;

--- a/src/tools/setup_config.rs
+++ b/src/tools/setup_config.rs
@@ -1,0 +1,83 @@
+//! setup_config tool -- generate initial skillet configuration
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use skillet_mcp::config;
+use skillet_mcp::registry;
+use skillet_mcp::state::AppState;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetupConfigInput {
+    /// Default install target (default: "agents"). Options: agents, claude, cursor, copilot, windsurf, gemini, all
+    #[serde(default)]
+    target: Option<String>,
+    /// Additional remote registry URLs to add beyond the official registry
+    #[serde(default)]
+    remotes: Vec<String>,
+    /// Overwrite existing config if present (default: false)
+    #[serde(default)]
+    force: Option<bool>,
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("setup_config")
+        .description(
+            "Generate initial skillet configuration at ~/.config/skillet/config.toml. \
+             Sets up the official registry, default install target, and standard \
+             defaults. Use this to help users get started with skillet.",
+        )
+        .extractor_handler(
+            state,
+            |State(_state): State<Arc<AppState>>, Json(input): Json<SetupConfigInput>| async move {
+                let config_path = config::config_dir().join("config.toml");
+
+                if config_path.exists() && !input.force.unwrap_or(false) {
+                    return Ok(CallToolResult::text(format!(
+                        "Config already exists at `{}`.\n\n\
+                         Pass `force: true` to overwrite, or edit the file directly.",
+                        config_path.display()
+                    )));
+                }
+
+                let target = input.target.as_deref().unwrap_or("agents");
+
+                // Build remotes: official + user-provided
+                let mut remotes = vec![registry::DEFAULT_REGISTRY_URL.to_string()];
+                remotes.extend(input.remotes);
+
+                let generated = match config::generate_default_config(remotes, vec![], target) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        return Ok(CallToolResult::error(format!("Invalid configuration: {e}")));
+                    }
+                };
+
+                let path = match config::write_config(&generated) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        return Ok(CallToolResult::error(format!(
+                            "Failed to write config: {e}"
+                        )));
+                    }
+                };
+
+                let content = std::fs::read_to_string(&path).unwrap_or_default();
+
+                Ok(CallToolResult::text(format!(
+                    "Wrote config to `{}`\n\n\
+                     ```toml\n{content}```\n\n\
+                     Skillet is now configured. Skills will be installed to \
+                     `.{target}/skills/` by default.",
+                    path.display(),
+                )))
+            },
+        )
+        .build()
+}

--- a/src/tools/validate_skill.rs
+++ b/src/tools/validate_skill.rs
@@ -1,0 +1,166 @@
+//! validate_skill tool -- validate a skillpack directory
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use skillet_mcp::config;
+use skillet_mcp::safety;
+use skillet_mcp::state::AppState;
+use skillet_mcp::validate;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ValidateSkillInput {
+    /// Path to the skillpack directory to validate
+    path: String,
+    /// Skip safety scanning (default: false)
+    #[serde(default)]
+    skip_safety: Option<bool>,
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("validate_skill")
+        .description(
+            "Validate a skillpack directory for correctness and safety. \
+             Checks skill.toml structure, SKILL.md presence, metadata fields, \
+             content hashes, and runs safety scanning. Use this when authoring \
+             or reviewing skills.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state,
+            |State(_state): State<Arc<AppState>>, Json(input): Json<ValidateSkillInput>| async move {
+                let path = PathBuf::from(&input.path);
+
+                let result = match validate::validate_skillpack(&path) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        return Ok(CallToolResult::error(format!(
+                            "Validation error: {e}"
+                        )));
+                    }
+                };
+
+                let mut output = format!("## Validation: {}/{}\n\n", result.owner, result.name);
+                output.push_str("- **skill.toml**: ok\n");
+                output.push_str(&format!(
+                    "- **SKILL.md**: ok ({} lines)\n",
+                    result.skill_md.lines().count()
+                ));
+                output.push_str(&format!("- **version**: {}\n", result.version));
+                output.push_str(&format!("- **description**: {}\n", result.description));
+
+                if let Some(ref classification) = result.metadata.skill.classification {
+                    if !classification.categories.is_empty() {
+                        output.push_str(&format!(
+                            "- **categories**: {}\n",
+                            classification.categories.join(", ")
+                        ));
+                    }
+                    if !classification.tags.is_empty() {
+                        output.push_str(&format!(
+                            "- **tags**: {}\n",
+                            classification.tags.join(", ")
+                        ));
+                    }
+                }
+
+                if !result.files.is_empty() {
+                    let mut file_paths: Vec<&String> = result.files.keys().collect();
+                    file_paths.sort();
+                    output.push_str(&format!(
+                        "- **extra files**: {}\n",
+                        file_paths
+                            .iter()
+                            .map(|s| s.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ));
+                }
+
+                // Content hash
+                let hash_display = if result.hashes.composite.len() > 17 {
+                    format!("{}...", &result.hashes.composite[..17])
+                } else {
+                    result.hashes.composite.clone()
+                };
+                output.push_str(&format!("- **content hash**: {hash_display}\n"));
+
+                // Manifest status
+                match result.manifest_ok {
+                    Some(true) => output.push_str("- **manifest**: verified\n"),
+                    Some(false) => output.push_str("- **manifest**: MISMATCH\n"),
+                    None => output.push_str("- **manifest**: not found (generated on pack)\n"),
+                }
+
+                // Warnings
+                if !result.warnings.is_empty() {
+                    output.push('\n');
+                    for w in &result.warnings {
+                        output.push_str(&format!("**Warning**: {w}\n"));
+                    }
+                }
+
+                // Safety scanning
+                if !input.skip_safety.unwrap_or(false) {
+                    let cli_config = config::load_config().unwrap_or_default();
+                    let report = safety::scan(
+                        &result.skill_md,
+                        &result.skill_toml_raw,
+                        &result.files,
+                        &result.metadata,
+                        &cli_config.safety.suppress,
+                    );
+
+                    if !report.is_empty() {
+                        let danger_count = report
+                            .findings
+                            .iter()
+                            .filter(|f| f.severity == safety::Severity::Danger)
+                            .count();
+                        let warning_count = report
+                            .findings
+                            .iter()
+                            .filter(|f| f.severity == safety::Severity::Warning)
+                            .count();
+
+                        output.push_str(&format!(
+                            "\n**Safety scan**: {danger_count} danger, {warning_count} warning\n"
+                        ));
+
+                        for f in &report.findings {
+                            let line_info = match f.line {
+                                Some(n) => format!("{}:{n}", f.file),
+                                None => f.file.clone(),
+                            };
+                            output.push_str(&format!(
+                                "\n- **[{severity}]** {line_info}: {msg} (`{matched}`)",
+                                severity = f.severity,
+                                msg = f.message,
+                                matched = f.matched,
+                            ));
+                        }
+
+                        if report.has_danger() {
+                            output.push_str(
+                                "\n\nValidation failed: safety issues detected. \
+                                 Fix danger findings before packing or publishing.",
+                            );
+                            return Ok(CallToolResult::text(output));
+                        }
+                    }
+                }
+
+                output.push_str("\n\nValidation passed.");
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}


### PR DESCRIPTION
## Summary

Closes the MCP tool gaps identified in #107 so agents can use core skillet functionality without falling back to CLI.

- **list_installed**: List all locally installed skills with version, path, and timestamp (#103)
- **audit_skills**: Verify installed skills against pinned content hashes for integrity (#104)
- **setup_config**: Generate initial `~/.config/skillet/config.toml` with sensible defaults (#105)
- **validate_skill**: Validate a skillpack directory for correctness and safety (#106)

All read-only tools are marked `.read_only().idempotent()`. `setup_config` is excluded in `--read-only` mode alongside `install_skill` since it writes to disk. README MCP tools table updated to reflect all 11 tools.

Closes #103, closes #104, closes #105, closes #106

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (201 passed)
- [x] `cargo test --bin skillet --all-features` (50 passed)
- [x] `cargo test --test '*' --all-features` (39 passed)
- [x] `cargo doc --no-deps --all-features`