### PR TITLE
docs: add Docker MCP config to quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ can search, read, and install skills at runtime:
 }
 ```
 
+Or with Docker (zero install):
+
+```json
+{
+  "mcpServers": {
+    "skillet": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "ghcr.io/joshrotenberg/skillet"]
+    }
+  }
+}
+```
+
 That's it. Skillet auto-discovers the
 [official registry](https://github.com/joshrotenberg/skillet-registry)
 and any skills already installed on your machine. Your agent now has


### PR DESCRIPTION
## Summary

- Add Docker zero-install MCP config example to the quick start section

Gives users a copy-paste option that requires no local installation.

## Test plan

- [x] README renders correctly