### PR TITLE
fix: add --version flag and fix commit signing (#114, #118)

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -342,7 +342,7 @@ mod tests {
             .output()
             .unwrap();
         std::process::Command::new("git")
-            .args(["commit", "-m", "first"])
+            .args(["-c", "commit.gpgsign=false", "commit", "-m", "first"])
             .current_dir(&git_dir)
             .output()
             .unwrap();
@@ -361,7 +361,7 @@ mod tests {
             .output()
             .unwrap();
         std::process::Command::new("git")
-            .args(["commit", "-m", "second"])
+            .args(["-c", "commit.gpgsign=false", "commit", "-m", "second"])
             .current_dir(&git_dir)
             .output()
             .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use skillet_mcp::{
 
 #[derive(Parser, Debug)]
 #[command(name = "skillet")]
+#[command(version)]
 #[command(about = "MCP-native skill registry for AI agents")]
 #[command(args_conflicts_with_subcommands = true)]
 struct Cli {

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -73,7 +73,10 @@ pub fn publish(dir: &Path, repo: &str, dry_run: bool) -> anyhow::Result<PublishR
     git_in(&clone_dir, &["add", &format!("{owner}/{name}")])?;
 
     let commit_msg = format!("feat: publish {owner}/{name} v{version}");
-    git_in(&clone_dir, &["commit", "-m", &commit_msg])?;
+    git_in(
+        &clone_dir,
+        &["-c", "commit.gpgsign=false", "commit", "-m", &commit_msg],
+    )?;
 
     git_in(&clone_dir, &["push", "-u", "origin", &branch])?;
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -199,7 +199,13 @@ pub fn init_registry(path: &Path, name: &str, description: Option<&str>) -> anyh
     }
 
     let output = std::process::Command::new("git")
-        .args(["commit", "-m", "Initialize skill registry"])
+        .args([
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-m",
+            "Initialize skill registry",
+        ])
         .current_dir(path)
         .output()?;
 


### PR DESCRIPTION
## Summary

- Add `--version` flag to CLI (#114) -- `skillet --version` now prints `skillet 0.1.0`
- Fix git commit commands failing with `commit.gpgsign=true` (#118) -- adds `-c commit.gpgsign=false` to all git commit invocations in `registry.rs`, `publish.rs`, and `cache.rs`

Note: #110 (CLAUDE.md naming) is a local-only file (gitignored), fixed locally.

Closes #114, closes #118, closes #110

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] 201 lib tests, 50 bin tests, 39 integration tests pass
- [x] `skillet --version` outputs `skillet 0.1.0`