### PR TITLE
feat: add --require-trusted flag and improve trust warnings (#112, #117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,8 +420,9 @@ ttl = "5m"              # index cache time-to-live
 suppress = []           # rule IDs to suppress
 
 [trust]
-unknown_policy = "warn" # "warn", "prompt", or "block"
-auto_pin = true         # pin content hash on install
+unknown_policy = "warn"   # "warn", "prompt", or "block"
+auto_pin = true           # pin content hash on install
+require_trusted = false   # block installs from unknown sources
 
 [server]
 tools = []              # empty = expose all

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,6 +71,10 @@ pub struct TrustConfig {
     pub unknown_policy: String,
     /// Automatically pin content hash on install.
     pub auto_pin: bool,
+    /// Require trusted registry or pinned hash for installs.
+    /// When true, blocks installs from unknown sources.
+    #[serde(default)]
+    pub require_trusted: bool,
 }
 
 impl Default for TrustConfig {
@@ -78,6 +82,7 @@ impl Default for TrustConfig {
         Self {
             unknown_policy: "warn".to_string(),
             auto_pin: true,
+            require_trusted: false,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,6 +231,10 @@ struct InstallArgs {
     #[arg(long)]
     version: Option<String>,
 
+    /// Require trusted registry or pinned hash (blocks unknown sources)
+    #[arg(long)]
+    require_trusted: bool,
+
     #[command(flatten)]
     registries: RegistryArgs,
 }
@@ -843,13 +847,37 @@ fn run_install(args: InstallArgs) -> ExitCode {
             }
         }
         trust::TrustTier::Unknown => {
+            // --require-trusted flag or config overrides policy
+            if args.require_trusted || cli_config.trust.require_trusted {
+                eprintln!(
+                    "Error: {reason}\n\n\
+                     Install blocked: --require-trusted is set.\n\
+                     To install this skill, either:\n\
+                     \n  1. Trust the registry:\n\
+                     \n     skillet trust add-registry {registry_id}\n\
+                     \n  2. Review and pin the skill:\n\
+                     \n     skillet info {owner}/{name}\n\
+                     \n     skillet trust pin {owner}/{name}\n\
+                     \n     skillet install {owner}/{name}\n",
+                    reason = trust_check.reason,
+                );
+                return ExitCode::from(1);
+            }
+
             let policy = &cli_config.trust.unknown_policy;
             match policy.as_str() {
                 "block" => {
                     eprintln!(
-                        "Error: {}\nInstall blocked by trust policy (unknown_policy = \"block\").\n\
-                         Trust this registry with: skillet trust add-registry {registry_id}",
-                        trust_check.reason
+                        "Error: {reason}\n\n\
+                         Install blocked by trust policy (unknown_policy = \"block\").\n\
+                         To install this skill, either:\n\
+                         \n  1. Trust the registry:\n\
+                         \n     skillet trust add-registry {registry_id}\n\
+                         \n  2. Review and pin the skill:\n\
+                         \n     skillet info {owner}/{name}\n\
+                         \n     skillet trust pin {owner}/{name}\n\
+                         \n     skillet install {owner}/{name}\n",
+                        reason = trust_check.reason,
                     );
                     return ExitCode::from(1);
                 }
@@ -867,8 +895,14 @@ fn run_install(args: InstallArgs) -> ExitCode {
                     }
                 }
                 _ => {
-                    // "warn" (default)
-                    eprintln!("Warning: {}", trust_check.reason);
+                    // "warn" (default) -- explicit guidance
+                    eprintln!(
+                        "Warning: {reason}\n\
+                         To verify before installing:\n\
+                         \n  skillet info {owner}/{name}\n\
+                         \n  skillet trust pin {owner}/{name}\n",
+                        reason = trust_check.reason,
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Add `--require-trusted` CLI flag and `[trust].require_trusted` config option (#112)
  - Blocks installs from unknown sources (untrusted registry + unpinned skill)
  - CLI flag and config both supported; flag overrides config
  - MCP `install_skill` tool respects config setting
- Improve Unknown trust tier warnings with actionable guidance (#117)
  - All policy paths (block, warn, require-trusted) now show step-by-step instructions
  - Guides users through `skillet info`, `skillet trust pin`, or `skillet trust add-registry`

Closes #112, closes #117

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] 201 lib tests, 50 bin tests, 39 integration tests pass