### PR TITLE
refactor: consolidate error handling across library modules (#115)

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -176,7 +176,7 @@ pub fn write(source: &RegistrySource, index: &SkillIndex) {
 }
 
 /// Remove all index cache files.
-pub fn clear() -> anyhow::Result<()> {
+pub fn clear() -> crate::error::Result<()> {
     let dir = cache_dir();
     if dir.exists() {
         std::fs::remove_dir_all(&dir)?;

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -3,8 +3,7 @@
 use std::path::Path;
 use std::process::Command;
 
-use anyhow::{Context, bail};
-
+use crate::error::Error;
 use crate::pack::{self, PackResult};
 
 /// Result of publishing a skillpack.
@@ -18,7 +17,7 @@ pub struct PublishResult {
 ///
 /// `repo` is in `owner/repo` format (e.g. "joshrotenberg/skillet-registry").
 /// If `dry_run` is true, stops after packing and prints what would happen.
-pub fn publish(dir: &Path, repo: &str, dry_run: bool) -> anyhow::Result<PublishResult> {
+pub fn publish(dir: &Path, repo: &str, dry_run: bool) -> crate::error::Result<PublishResult> {
     let pack_result = pack::pack(dir)?;
 
     let owner = &pack_result.validation.owner;
@@ -41,7 +40,10 @@ pub fn publish(dir: &Path, repo: &str, dry_run: bool) -> anyhow::Result<PublishR
     check_gh_cli()?;
 
     // Fork + clone the registry repo
-    let tmpdir = tempfile::tempdir().context("Failed to create temp directory")?;
+    let tmpdir = tempfile::tempdir().map_err(|e| Error::Io {
+        context: "failed to create temp directory".to_string(),
+        source: e,
+    })?;
     let clone_dir = tmpdir.path().join("registry");
 
     gh(&[
@@ -56,7 +58,7 @@ pub fn publish(dir: &Path, repo: &str, dry_run: bool) -> anyhow::Result<PublishR
         // Fork may already exist; try cloning directly
         gh(&["repo", "clone", repo, &clone_dir.display().to_string()])
     })
-    .context("Failed to fork/clone registry repo")?;
+    .map_err(|_| Error::Publish(format!("failed to fork/clone registry repo {repo}")))?;
 
     // Create a publish branch
     let branch = format!("publish/{owner}/{name}/{version}");
@@ -64,8 +66,10 @@ pub fn publish(dir: &Path, repo: &str, dry_run: bool) -> anyhow::Result<PublishR
 
     // Copy the packed skillpack into the registry checkout
     let dest = clone_dir.join(owner).join(name);
-    std::fs::create_dir_all(&dest)
-        .with_context(|| format!("Failed to create {}", dest.display()))?;
+    std::fs::create_dir_all(&dest).map_err(|e| Error::CreateDir {
+        path: dest.clone(),
+        source: e,
+    })?;
 
     copy_skillpack(dir, &dest)?;
 
@@ -103,19 +107,24 @@ pub fn publish(dir: &Path, repo: &str, dry_run: bool) -> anyhow::Result<PublishR
 }
 
 /// Copy skill files from source to destination directory.
-fn copy_skillpack(src: &Path, dst: &Path) -> anyhow::Result<()> {
+fn copy_skillpack(src: &Path, dst: &Path) -> crate::error::Result<()> {
     let required = ["skill.toml", "SKILL.md", "MANIFEST.sha256"];
     for name in &required {
         let from = src.join(name);
         let to = dst.join(name);
-        std::fs::copy(&from, &to).with_context(|| format!("Failed to copy {}", from.display()))?;
+        std::fs::copy(&from, &to).map_err(|e| Error::Io {
+            context: format!("failed to copy {}", from.display()),
+            source: e,
+        })?;
     }
 
     // versions.toml
     let versions_src = src.join("versions.toml");
     if versions_src.is_file() {
-        std::fs::copy(&versions_src, dst.join("versions.toml"))
-            .context("Failed to copy versions.toml")?;
+        std::fs::copy(&versions_src, dst.join("versions.toml")).map_err(|e| Error::Io {
+            context: "failed to copy versions.toml".to_string(),
+            source: e,
+        })?;
     }
 
     // Extra directories: scripts/, references/, assets/
@@ -129,27 +138,36 @@ fn copy_skillpack(src: &Path, dst: &Path) -> anyhow::Result<()> {
     // README.md (optional)
     let readme_src = src.join("README.md");
     if readme_src.is_file() {
-        std::fs::copy(&readme_src, dst.join("README.md")).context("Failed to copy README.md")?;
+        std::fs::copy(&readme_src, dst.join("README.md")).map_err(|e| Error::Io {
+            context: "failed to copy README.md".to_string(),
+            source: e,
+        })?;
     }
 
     Ok(())
 }
 
 /// Recursively copy a directory.
-fn copy_dir_recursive(src: &Path, dst: &Path) -> anyhow::Result<()> {
-    std::fs::create_dir_all(dst).with_context(|| format!("Failed to create {}", dst.display()))?;
+fn copy_dir_recursive(src: &Path, dst: &Path) -> crate::error::Result<()> {
+    std::fs::create_dir_all(dst).map_err(|e| Error::CreateDir {
+        path: dst.to_path_buf(),
+        source: e,
+    })?;
 
-    for entry in
-        std::fs::read_dir(src).with_context(|| format!("Failed to read {}", src.display()))?
-    {
+    for entry in std::fs::read_dir(src).map_err(|e| Error::FileRead {
+        path: src.to_path_buf(),
+        source: e,
+    })? {
         let entry = entry?;
         let src_path = entry.path();
         let dst_path = dst.join(entry.file_name());
         if src_path.is_dir() {
             copy_dir_recursive(&src_path, &dst_path)?;
         } else {
-            std::fs::copy(&src_path, &dst_path)
-                .with_context(|| format!("Failed to copy {}", src_path.display()))?;
+            std::fs::copy(&src_path, &dst_path).map_err(|e| Error::Io {
+                context: format!("failed to copy {}", src_path.display()),
+                source: e,
+            })?;
         }
     }
 
@@ -157,7 +175,7 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> anyhow::Result<()> {
 }
 
 /// Check that `gh` CLI is available and authenticated.
-fn check_gh_cli() -> anyhow::Result<()> {
+fn check_gh_cli() -> crate::error::Result<()> {
     let status = Command::new("gh")
         .args(["auth", "status"])
         .stdout(std::process::Stdio::null())
@@ -166,53 +184,77 @@ fn check_gh_cli() -> anyhow::Result<()> {
 
     match status {
         Ok(s) if s.success() => Ok(()),
-        Ok(_) => bail!("gh CLI is not authenticated. Run `gh auth login` first."),
-        Err(_) => bail!("gh CLI not found. Install it from https://cli.github.com/"),
+        Ok(_) => Err(Error::Publish(
+            "gh CLI is not authenticated. Run `gh auth login` first.".to_string(),
+        )),
+        Err(_) => Err(Error::Publish(
+            "gh CLI not found. Install it from https://cli.github.com/".to_string(),
+        )),
     }
 }
 
 /// Run a `gh` command and return stdout.
-fn gh(args: &[&str]) -> anyhow::Result<String> {
+fn gh(args: &[&str]) -> crate::error::Result<String> {
     let output = Command::new("gh")
         .args(args)
         .output()
-        .context("Failed to run gh")?;
+        .map_err(|e| Error::Io {
+            context: "failed to run gh".to_string(),
+            source: e,
+        })?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!("gh {} failed: {}", args.first().unwrap_or(&""), stderr);
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(Error::Publish(format!(
+            "gh {} failed: {}",
+            args.first().unwrap_or(&""),
+            stderr
+        )));
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 /// Run a `gh` command in a specific directory.
-fn gh_in(dir: &Path, args: &[&str]) -> anyhow::Result<String> {
+fn gh_in(dir: &Path, args: &[&str]) -> crate::error::Result<String> {
     let output = Command::new("gh")
         .args(args)
         .current_dir(dir)
         .output()
-        .context("Failed to run gh")?;
+        .map_err(|e| Error::Io {
+            context: "failed to run gh".to_string(),
+            source: e,
+        })?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!("gh {} failed: {}", args.first().unwrap_or(&""), stderr);
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(Error::Publish(format!(
+            "gh {} failed: {}",
+            args.first().unwrap_or(&""),
+            stderr
+        )));
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 /// Run a `git` command in a specific directory.
-fn git_in(dir: &Path, args: &[&str]) -> anyhow::Result<String> {
+fn git_in(dir: &Path, args: &[&str]) -> crate::error::Result<String> {
     let output = Command::new("git")
         .args(args)
         .current_dir(dir)
         .output()
-        .context("Failed to run git")?;
+        .map_err(|e| Error::Io {
+            context: "failed to run git".to_string(),
+            source: e,
+        })?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!("git {} failed: {}", args.first().unwrap_or(&""), stderr);
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(Error::Git {
+            operation: args.first().unwrap_or(&"").to_string(),
+            stderr,
+        });
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use crate::cache::{self, RegistrySource};
 use crate::config::SkilletConfig;
+use crate::error::Error;
 use crate::state::SkillIndex;
 use crate::{git, index};
 
@@ -12,7 +13,7 @@ use crate::{git, index};
 pub const DEFAULT_REGISTRY_URL: &str = "https://github.com/joshrotenberg/skillet-registry.git";
 
 /// Parse a human-friendly duration string like "5m", "1h", "30s", or "0".
-pub fn parse_duration(s: &str) -> anyhow::Result<Duration> {
+pub fn parse_duration(s: &str) -> crate::error::Result<Duration> {
     let s = s.trim();
     if s == "0" {
         return Ok(Duration::ZERO);
@@ -21,13 +22,17 @@ pub fn parse_duration(s: &str) -> anyhow::Result<Duration> {
     let (num, suffix) = s.split_at(s.find(|c: char| !c.is_ascii_digit()).unwrap_or(s.len()));
     let num: u64 = num
         .parse()
-        .map_err(|_| anyhow::anyhow!("Invalid duration number: {s}"))?;
+        .map_err(|_| Error::InvalidDuration(format!("invalid number: {s}")))?;
 
     let secs = match suffix {
         "s" | "" => num,
         "m" => num * 60,
         "h" => num * 3600,
-        _ => anyhow::bail!("Unknown duration suffix: {suffix} (use s, m, or h)"),
+        _ => {
+            return Err(Error::InvalidDuration(format!(
+                "unknown suffix: {suffix} (use s, m, or h)"
+            )));
+        }
     };
 
     Ok(Duration::from_secs(secs))
@@ -71,7 +76,11 @@ pub fn default_cache_dir() -> PathBuf {
 /// then makes an initial commit. If `description` is provided, it is
 /// included in `config.toml`. Maintainer info is auto-populated from
 /// the user's git config when available.
-pub fn init_registry(path: &Path, name: &str, description: Option<&str>) -> anyhow::Result<()> {
+pub fn init_registry(
+    path: &Path,
+    name: &str,
+    description: Option<&str>,
+) -> crate::error::Result<()> {
     std::fs::create_dir_all(path)?;
 
     // config.toml
@@ -165,8 +174,11 @@ pub fn init_registry(path: &Path, name: &str, description: Option<&str>) -> anyh
         .output()?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git init failed: {stderr}");
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(Error::Git {
+            operation: "init".to_string(),
+            stderr,
+        });
     }
 
     // Set local git config if no global identity exists (e.g. in CI)
@@ -194,8 +206,11 @@ pub fn init_registry(path: &Path, name: &str, description: Option<&str>) -> anyh
         .output()?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git add failed: {stderr}");
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(Error::Git {
+            operation: "add".to_string(),
+            stderr,
+        });
     }
 
     let output = std::process::Command::new("git")
@@ -204,8 +219,11 @@ pub fn init_registry(path: &Path, name: &str, description: Option<&str>) -> anyh
         .output()?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git commit failed: {stderr}");
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(Error::Git {
+            operation: "commit".to_string(),
+            stderr,
+        });
     }
 
     Ok(())
@@ -224,7 +242,7 @@ pub fn load_registries(
     remote_flags: &[String],
     config: &SkilletConfig,
     subdir: Option<&Path>,
-) -> anyhow::Result<(SkillIndex, Vec<PathBuf>)> {
+) -> crate::error::Result<(SkillIndex, Vec<PathBuf>)> {
     let has_flags = !registry_flags.is_empty() || !remote_flags.is_empty();
 
     let (local_paths, remote_urls): (Vec<PathBuf>, Vec<&str>) = if has_flags {

--- a/src/scaffold.rs
+++ b/src/scaffold.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use anyhow::bail;
+use crate::error::Error;
 
 /// Initialize a new skillpack at the given path.
 ///
@@ -15,9 +15,12 @@ pub fn init_skill(
     description: &str,
     categories: &[String],
     tags: &[String],
-) -> anyhow::Result<()> {
+) -> crate::error::Result<()> {
     if path.exists() {
-        bail!("{} already exists", path.display());
+        return Err(Error::Scaffold(format!(
+            "{} already exists",
+            path.display()
+        )));
     }
 
     std::fs::create_dir_all(path)?;


### PR DESCRIPTION
## Summary

Migrate all library modules from `anyhow` to the custom `crate::error::{Error, Result}` type. Extends `error.rs` with 10 new module-specific error variants.

| Module | Variants added | Change |
|--------|----------------|--------|
| `integrity.rs` | `ManifestFormatError`, `ManifestMissingComposite` | `anyhow::bail!` -> typed errors |
| `scaffold.rs` | `Scaffold(String)` | `anyhow::bail!` -> typed error |
| `git.rs` | `Git { operation, stderr }` | All 4 public functions migrated |
| `registry.rs` | `InvalidDuration(String)` | `parse_duration`, `init_registry`, `load_registries` |
| `cache.rs` | (uses existing `Io`) | `clear()` only |
| `validate.rs` | `Validation(String)` | `validate_skillpack` + all internal calls |
| `index.rs` | `SkillLoad`, `TomlParse`, `FileRead` | Most complex migration (5 public functions) |
| `pack.rs` | (uses existing variants) | `pack`, `update_versions_toml` |
| `publish.rs` | `Publish(String)` | All functions migrated |

Intentionally unchanged: `discover.rs` (private, errors swallowed), `main.rs` (application code where anyhow is appropriate).

Closes #115

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] 201 lib tests, 50 bin tests, 39 integration tests pass