### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-02-28
+
+### Bug Fixes
+
+- Load official registry catalog even with custom remotes ([#167](https://github.com/joshrotenberg/skillet/pull/167))
+- Index external repos with flat directory structures ([#169](https://github.com/joshrotenberg/skillet/pull/169))
+
+### Features
+
+- Support nested skill directories in registries ([#126](https://github.com/joshrotenberg/skillet/pull/126)) ([#127](https://github.com/joshrotenberg/skillet/pull/127))
+- Implement skillet.toml unified project manifest ([#148](https://github.com/joshrotenberg/skillet/pull/148))
+- Support npm-style skill repos as registries ([#152](https://github.com/joshrotenberg/skillet/pull/152))
+- Move official registry into main repo ([#159](https://github.com/joshrotenberg/skillet/pull/159))
+- Add skill-repos skill with curated external skill sources ([#160](https://github.com/joshrotenberg/skillet/pull/160))
+- Add repo catalog and resource templates ([#166](https://github.com/joshrotenberg/skillet/pull/166))
+
+### Miscellaneous Tasks
+
+- Add MIT and Apache-2.0 license files ([#124](https://github.com/joshrotenberg/skillet/pull/124))
+- Remove legacy config.toml registry support ([#161](https://github.com/joshrotenberg/skillet/pull/161))
+
+### Refactor
+
+- Remove repo catalog, move curation to SKILL.md ([#170](https://github.com/joshrotenberg/skillet/pull/170))
+
+### Testing
+
+- Add unit tests for state, git, and publish modules ([#153](https://github.com/joshrotenberg/skillet/pull/153))
+- Expand coverage for install, pack, and registry modules ([#154](https://github.com/joshrotenberg/skillet/pull/154))
+- Add integration tests for CLI hygiene, publish, and audit/trust ([#155](https://github.com/joshrotenberg/skillet/pull/155))
+- Add scenario tests for publish, project manifest, config, and error recovery ([#156](https://github.com/joshrotenberg/skillet/pull/156))
+- Add MCP integration tests for tools, resources, and local discovery ([#157](https://github.com/joshrotenberg/skillet/pull/157))
+- Add HTTP transport integration tests ([#158](https://github.com/joshrotenberg/skillet/pull/158))
+
+
+
 ## [0.2.0] - 2026-02-27
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "skillet-mcp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillet-mcp"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.90"
 description = "MCP-native skill registry for AI agents"


### PR DESCRIPTION



## 🤖 New release

* `skillet-mcp`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `skillet-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SkillEntry.registry_path in /tmp/.tmpwSYa8S/skillet/src/state.rs:218

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant SkillSource:Embedded in /tmp/.tmpwSYa8S/skillet/src/state.rs:183

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  skillet_mcp::publish::publish now takes 4 parameters instead of 3, in /tmp/.tmpwSYa8S/skillet/src/publish.rs:23
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0] - 2026-02-28

### Bug Fixes

- Load official registry catalog even with custom remotes ([#167](https://github.com/joshrotenberg/skillet/pull/167))
- Index external repos with flat directory structures ([#169](https://github.com/joshrotenberg/skillet/pull/169))

### Features

- Support nested skill directories in registries ([#126](https://github.com/joshrotenberg/skillet/pull/126)) ([#127](https://github.com/joshrotenberg/skillet/pull/127))
- Implement skillet.toml unified project manifest ([#148](https://github.com/joshrotenberg/skillet/pull/148))
- Support npm-style skill repos as registries ([#152](https://github.com/joshrotenberg/skillet/pull/152))
- Move official registry into main repo ([#159](https://github.com/joshrotenberg/skillet/pull/159))
- Add skill-repos skill with curated external skill sources ([#160](https://github.com/joshrotenberg/skillet/pull/160))
- Add repo catalog and resource templates ([#166](https://github.com/joshrotenberg/skillet/pull/166))

### Miscellaneous Tasks

- Add MIT and Apache-2.0 license files ([#124](https://github.com/joshrotenberg/skillet/pull/124))
- Remove legacy config.toml registry support ([#161](https://github.com/joshrotenberg/skillet/pull/161))

### Refactor

- Remove repo catalog, move curation to SKILL.md ([#170](https://github.com/joshrotenberg/skillet/pull/170))

### Testing

- Add unit tests for state, git, and publish modules ([#153](https://github.com/joshrotenberg/skillet/pull/153))
- Expand coverage for install, pack, and registry modules ([#154](https://github.com/joshrotenberg/skillet/pull/154))
- Add integration tests for CLI hygiene, publish, and audit/trust ([#155](https://github.com/joshrotenberg/skillet/pull/155))
- Add scenario tests for publish, project manifest, config, and error recovery ([#156](https://github.com/joshrotenberg/skillet/pull/156))
- Add MCP integration tests for tools, resources, and local discovery ([#157](https://github.com/joshrotenberg/skillet/pull/157))
- Add HTTP transport integration tests ([#158](https://github.com/joshrotenberg/skillet/pull/158))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).