### PR TITLE
feat: support nested skill directories in registries

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -217,6 +217,7 @@ mod tests {
         let entry = SkillEntry {
             owner: "test-owner".to_string(),
             name: "test-skill".to_string(),
+            registry_path: None,
             source: Default::default(),
             versions: vec![SkillVersion {
                 version: "0.1.0".to_string(),
@@ -448,6 +449,7 @@ mod tests {
         let entry = SkillEntry {
             owner: "owner".to_string(),
             name: "with-files".to_string(),
+            registry_path: None,
             source: Default::default(),
             versions: vec![SkillVersion {
                 version: "1.0.0".to_string(),

--- a/src/cli/author.rs
+++ b/src/cli/author.rs
@@ -171,7 +171,12 @@ pub(crate) fn run_publish(args: PublishArgs) -> ExitCode {
     let path = &args.path;
     println!("Publishing {} to {} ...\n", path.display(), args.repo);
 
-    let result = match publish::publish(path, &args.repo, args.dry_run) {
+    let result = match publish::publish(
+        path,
+        &args.repo,
+        args.registry_path.as_deref(),
+        args.dry_run,
+    ) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("  error: {e}");

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -296,6 +296,11 @@ pub(crate) fn run_info(args: InfoArgs) -> ExitCode {
         println!("  versions .............. {}", available.join(", "));
     }
 
+    // Registry path for nested skills
+    if let Some(ref rpath) = entry.registry_path {
+        println!("  registry path ......... {rpath}");
+    }
+
     ExitCode::SUCCESS
 }
 

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -123,6 +123,7 @@ fn build_local_entry(name: &str, path: &Path, platform: &str) -> anyhow::Result<
     Ok(SkillEntry {
         owner: "local".to_string(),
         name: name.to_string(),
+        registry_path: None,
         source: SkillSource::Local {
             platform: platform.to_string(),
             path: path.to_path_buf(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,6 +182,11 @@ struct PublishArgs {
     #[arg(long)]
     repo: String,
 
+    /// Override the destination path in the registry (e.g. "acme/lang/java/maven-build").
+    /// If not set, defaults to `owner/name/`.
+    #[arg(long)]
+    registry_path: Option<String>,
+
     /// Validate and show what would happen without creating a PR
     #[arg(long)]
     dry_run: bool,
@@ -1626,6 +1631,7 @@ mod tests {
             SkillEntry {
                 owner: "local".to_string(),
                 name: "my-local-skill".to_string(),
+                registry_path: None,
                 versions: vec![SkillVersion {
                     version: "0.0.0".to_string(),
                     metadata: SkillMetadata {
@@ -1732,6 +1738,7 @@ mod tests {
             SkillEntry {
                 owner: "testowner".to_string(),
                 name: "yanked-skill".to_string(),
+                registry_path: None,
                 versions: vec![SkillVersion {
                     version: "1.0.0".to_string(),
                     metadata: SkillMetadata {
@@ -1805,6 +1812,7 @@ mod tests {
             SkillEntry {
                 owner: "testowner".to_string(),
                 name: "yanked-skill".to_string(),
+                registry_path: None,
                 versions: vec![SkillVersion {
                     version: "1.0.0".to_string(),
                     metadata: SkillMetadata {

--- a/src/search.rs
+++ b/src/search.rs
@@ -124,6 +124,7 @@ mod tests {
         SkillEntry {
             owner: owner.to_string(),
             name: name.to_string(),
+            registry_path: None,
             source: Default::default(),
             versions: vec![SkillVersion {
                 version: "1.0.0".to_string(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -204,6 +204,10 @@ impl SkillSource {
 pub struct SkillEntry {
     pub owner: String,
     pub name: String,
+    /// Relative path from registry root (e.g., "acme/lang/java/maven-build").
+    /// None for flat skills at the standard `owner/name/` depth.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub registry_path: Option<String>,
     pub versions: Vec<SkillVersion>,
     #[serde(default)]
     pub source: SkillSource,

--- a/src/tools/info_skill.rs
+++ b/src/tools/info_skill.rs
@@ -139,6 +139,11 @@ pub fn build(state: Arc<AppState>) -> Tool {
                     output.push_str(&format!("**Versions:** {}\n", available.join(", ")));
                 }
 
+                // Registry path for nested skills
+                if let Some(ref rpath) = entry.registry_path {
+                    output.push_str(&format!("**Registry path:** {rpath}\n"));
+                }
+
                 // Source label for local skills
                 if let Some(label) = entry.source.label() {
                     output.push_str(&format!("**Source:** {label}\n"));

--- a/test-registry/acme/lang/java/gradle-build/SKILL.md
+++ b/test-registry/acme/lang/java/gradle-build/SKILL.md
@@ -1,0 +1,7 @@
+# Gradle Build
+
+Standard Gradle build conventions for Java projects.
+
+## Usage
+
+Use `./gradlew build` to compile and test.

--- a/test-registry/acme/lang/java/gradle-build/skill.toml
+++ b/test-registry/acme/lang/java/gradle-build/skill.toml
@@ -1,0 +1,9 @@
+[skill]
+name = "gradle-build"
+owner = "acme"
+version = "1.0.0"
+description = "Gradle build conventions and best practices for Java projects"
+
+[skill.classification]
+categories = ["java", "build-tools"]
+tags = ["gradle", "java", "build"]

--- a/test-registry/acme/lang/java/maven-build/SKILL.md
+++ b/test-registry/acme/lang/java/maven-build/SKILL.md
@@ -1,0 +1,7 @@
+# Maven Build
+
+Standard Maven build conventions for Java projects.
+
+## Usage
+
+Use `mvn clean install` to build and test.

--- a/test-registry/acme/lang/java/maven-build/skill.toml
+++ b/test-registry/acme/lang/java/maven-build/skill.toml
@@ -1,0 +1,9 @@
+[skill]
+name = "maven-build"
+owner = "acme"
+version = "1.0.0"
+description = "Maven build conventions and best practices for Java projects"
+
+[skill.classification]
+categories = ["java", "build-tools"]
+tags = ["maven", "java", "build"]


### PR DESCRIPTION
## Summary

Closes #126.

- Replace flat two-level directory walk with recursive `find_skill_dirs()` that descends up to 5 levels below each owner, allowing grouping directories like `acme/lang/java/maven-build/`
- Add `registry_path: Option<String>` to `SkillEntry` so nested paths are visible in info output and usable by publish
- Detect and warn on `(owner, name)` collisions from different nested paths (first-wins, matching multi-registry merge semantics)
- Add `--registry-path` flag to `skillet publish` to place skills at a custom path in the registry
- Show registry path in both MCP `info_skill` and CLI `skillet info` output

## Test plan

- [x] 6 new unit tests in `src/index.rs`: discovery, categories, registry_path, tempdir mixed layout, max depth, collision detection
- [x] 1 new scenario test: search -> info -> install -> list -> verify content for nested skill
- [x] All existing tests pass (207 lib + 50 bin + 40 integration)
- [x] `cargo fmt`, `cargo clippy`, `cargo doc` all clean