### PR TITLE
feat: support npm-style skill repos as registries

### DIFF
--- a/test-npm-registry/skillet.toml
+++ b/test-npm-registry/skillet.toml
@@ -1,0 +1,12 @@
+[project]
+name = "redis-skills"
+description = "Redis agent skills for AI assistants"
+license = "MIT"
+categories = ["database"]
+
+[[project.authors]]
+name = "Redis, Inc."
+github = "redis"
+
+[skills]
+path = "skills"

--- a/test-npm-registry/skills/redis-caching/SKILL.md
+++ b/test-npm-registry/skills/redis-caching/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: redis-caching
+description: Best practices for Redis caching patterns
+version: 2.1.0
+tags: [caching, redis, performance]
+author: Redis Team
+---
+
+# Redis Caching
+
+Comprehensive guide to Redis caching patterns for AI-assisted development.
+
+## Cache Strategies
+
+- Cache-aside (lazy loading)
+- Write-through
+- Write-behind (write-back)
+
+## TTL Management
+
+Always set appropriate TTL values based on data volatility.
+
+## Rules
+
+See the `rules/` directory for detailed caching rules and TTL guidelines.

--- a/test-npm-registry/skills/redis-caching/rules/cache-patterns.md
+++ b/test-npm-registry/skills/redis-caching/rules/cache-patterns.md
@@ -1,0 +1,13 @@
+# Cache Patterns
+
+## Cache-Aside
+
+1. Check cache first
+2. On miss, read from database
+3. Populate cache with result
+4. Return data
+
+## Write-Through
+
+1. Write to cache and database simultaneously
+2. Ensures consistency at cost of latency

--- a/test-npm-registry/skills/redis-caching/rules/ttl-guidelines.md
+++ b/test-npm-registry/skills/redis-caching/rules/ttl-guidelines.md
@@ -1,0 +1,16 @@
+# TTL Guidelines
+
+## Short TTL (seconds to minutes)
+- Session tokens
+- Rate limit counters
+- Real-time analytics
+
+## Medium TTL (minutes to hours)
+- API response caches
+- User preferences
+- Search results
+
+## Long TTL (hours to days)
+- Static content metadata
+- Feature flags
+- Configuration values

--- a/test-npm-registry/skills/session-management/SKILL.md
+++ b/test-npm-registry/skills/session-management/SKILL.md
@@ -1,0 +1,13 @@
+# Session Management
+
+Redis-based session management for web applications.
+
+## Usage
+
+Store session data in Redis with appropriate TTL for session expiry.
+
+## Best Practices
+
+- Use Redis hashes for session data
+- Set TTL matching session timeout
+- Use key prefixes for namespace isolation

--- a/test-npm-registry/skills/vector-search/SKILL.md
+++ b/test-npm-registry/skills/vector-search/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: vector-search
+description: Redis vector search and embedding patterns
+version: 1.5.0
+tags: [vectors, search, embeddings]
+---
+
+# Vector Search
+
+Guide to using Redis as a vector database for semantic search.
+
+## Setup
+
+Use the RediSearch module with vector similarity search capabilities.
+
+## Embedding Guide
+
+See `references/embedding-guide.md` for detailed embedding strategies.

--- a/test-npm-registry/skills/vector-search/references/embedding-guide.md
+++ b/test-npm-registry/skills/vector-search/references/embedding-guide.md
@@ -1,0 +1,13 @@
+# Embedding Guide
+
+## Choosing an Embedding Model
+
+- OpenAI text-embedding-3-small: good balance of cost and quality
+- Cohere embed-v3: multilingual support
+- Local models: sentence-transformers for privacy
+
+## Indexing Strategy
+
+1. Choose vector dimensions matching your model
+2. Use HNSW for approximate nearest neighbor search
+3. Set M and EF_CONSTRUCTION parameters based on dataset size


### PR DESCRIPTION
## Summary

- Add compatibility with npm-based agent skill repos (`redis/agent-skills`, `anthropics/skills`, `vercel-labs/agent-skills`, etc.) that use a flat `skills/<name>/SKILL.md` layout with YAML frontmatter metadata
- Any npm skill repo becomes skillet-compatible by adding a single `skillet.toml` at the repo root
- Extend `EXTRA_DIRS` with `rules/` and `templates/` directories common in npm skill repos
- Add YAML frontmatter parser (no new dependencies) for SKILL.md metadata extraction
- Bridge `load_index()` to detect `skillet.toml` `[skills]` sections, making `--registry` work with npm-style repos

## Example

A repo like `redis/agent-skills` with structure:
```
skills/
  redis-caching/
    SKILL.md       # has YAML frontmatter
    rules/
      cache-patterns.md
  vector-search/
    SKILL.md
    references/
      embedding-guide.md
```

Becomes a skillet registry with one file:
```toml
# skillet.toml
[project]
name = "redis-skills"

[[project.authors]]
github = "redis"

[skills]
path = "skills"
```

## Test plan

- [x] 8 unit tests for frontmatter parsing and metadata integration
- [x] 4 unit tests for rules/templates loading and npm-style load_index
- [x] 4 CLI integration tests (search, keyword search, info with/without frontmatter)
- [x] 1 scenario test (search -> info -> install with rules/ -> verify on disk)
- [x] `cargo fmt`, `clippy`, `cargo test --lib`, `cargo test --test '*'` all pass