### PR TITLE
fix: index external repos with flat directory structures

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -485,7 +485,7 @@ fn infer_owner(skill_dir: &Path, manifest: Option<&SkilletToml>) -> String {
 }
 
 /// Try to extract the repository owner from the git remote origin URL.
-fn owner_from_git_remote(dir: &Path) -> Option<String> {
+pub(crate) fn owner_from_git_remote(dir: &Path) -> Option<String> {
     let output = std::process::Command::new("git")
         .args(["remote", "get-url", "origin"])
         .current_dir(dir)


### PR DESCRIPTION
## Summary

- Add flat-repo fallback to `load_index()` that detects `skill-name/SKILL.md` layouts when the traditional `owner/name/SKILL.md` walk finds nothing
- Owner is inferred from the git remote URL (with `.git` root walk-up for subdir repos) or falls back to the directory name
- Only triggers when traditional indexing found zero skills, so existing repos are unaffected

## Test plan

- [x] `test_load_index_flat_repo_fallback` -- flat layout without git, owner inferred from directory name
- [x] `test_load_index_flat_repo_with_git_remote` -- git repo with remote, owner inferred from URL
- [x] `test_load_index_flat_repo_in_subdir` -- skills in subdirectory with git remote in parent
- [x] All 483 existing tests pass (316 lib + 65 bin + 66 CLI + 12 HTTP + 24 scenarios)
- [ ] Manual: `skillet search '*' --repo anthropics/skills`
- [ ] Manual: `skillet search react --repo vercel-labs/agent-skills`

Closes #168