### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-03-02
+
+### Bug Fixes
+
+- Scope uninstall to current project directory ([#173](https://github.com/joshrotenberg/skillet/pull/173))
+
+### Refactor
+
+- Design v2 -- remove publishing, simplify trust, rename registry to repo ([#171](https://github.com/joshrotenberg/skillet/pull/171))
+
+
+
 ## [0.3.0] - 2026-02-28
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "skillet-mcp"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillet-mcp"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.90"
 description = "MCP-native skill registry for AI agents"


### PR DESCRIPTION



## 🤖 New release

* `skillet-mcp`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `skillet-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SkillEntry.repo_path in /tmp/.tmptJUl7I/skillet/src/state.rs:153
  field SkilletConfig.repos in /tmp/.tmptJUl7I/skillet/src/config.rs:18
  field InstalledSkill.repo in /tmp/.tmptJUl7I/skillet/src/manifest.rs:28
  field AppState.repo_paths in /tmp/.tmptJUl7I/skillet/src/state.rs:19
  field InstallOptions.repo in /tmp/.tmptJUl7I/skillet/src/install.rs:21
  field PinnedSkill.repo in /tmp/.tmptJUl7I/skillet/src/trust.rs:41

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum skillet_mcp::cache::RegistrySource, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/cache.rs:22

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant TrustTier::Reviewed 1 -> 0 in /tmp/.tmptJUl7I/skillet/src/trust.rs:20
  variant TrustTier::Unknown 2 -> 1 in /tmp/.tmptJUl7I/skillet/src/trust.rs:22
  variant ManifestRole::SingleSkill 1 -> 0 in /tmp/.tmptJUl7I/skillet/src/project.rs:143
  variant ManifestRole::MultiSkill 2 -> 1 in /tmp/.tmptJUl7I/skillet/src/project.rs:145
  variant ManifestRole::ProjectOnly 3 -> 2 in /tmp/.tmptJUl7I/skillet/src/project.rs:147

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant SkillSource:Repo in /tmp/.tmptJUl7I/skillet/src/state.rs:105

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant TrustTier::Trusted, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/trust.rs:21
  variant Error::Publish, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/error.rs:119
  variant ManifestRole::Registry, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/project.rs:189
  variant SkillSource::Registry, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/state.rs:174

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function skillet_mcp::pack::pack, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/pack.rs:24
  function skillet_mcp::registry::cache_dir_for_url, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/registry.rs:47
  function skillet_mcp::registry::load_registries, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/registry.rs:251
  function skillet_mcp::scaffold::init_project, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/scaffold.rs:139
  function skillet_mcp::scaffold::init_skill, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/scaffold.rs:11
  function skillet_mcp::registry::parse_duration, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/registry.rs:19
  function skillet_mcp::registry::init_registry, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/registry.rs:84
  function skillet_mcp::publish::publish, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/publish.rs:23
  function skillet_mcp::registry::default_cache_dir, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/registry.rs:68
  function skillet_mcp::registry::registry_id, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/registry.rs:363

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  SkilletToml::into_registry_config, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/project.rs:216
  TrustState::add_registry, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/trust.rs:164
  TrustState::remove_registry, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/trust.rs:176
  TrustState::is_trusted, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/trust.rs:183

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod skillet_mcp::publish, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/publish.rs:1
  mod skillet_mcp::pack, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/pack.rs:1
  mod skillet_mcp::registry, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/registry.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  DEFAULT_REGISTRY_URL in file /tmp/.tmpkfY8lA/skillet-mcp/src/registry.rs:13
  DEFAULT_REGISTRY_SUBDIR in file /tmp/.tmpkfY8lA/skillet-mcp/src/registry.rs:16

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct skillet_mcp::state::RegistryConfig, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/state.rs:46
  struct skillet_mcp::pack::PackResult, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/pack.rs:13
  struct skillet_mcp::state::RegistryMaintainer, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/state.rs:91
  struct skillet_mcp::state::RegistrySuggestion, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/state.rs:99
  struct skillet_mcp::state::RegistryUrls, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/state.rs:113
  struct skillet_mcp::publish::PublishResult, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/publish.rs:12
  struct skillet_mcp::state::RegistryInfo, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/state.rs:70
  struct skillet_mcp::scaffold::InitProjectOptions, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/scaffold.rs:122
  struct skillet_mcp::state::RegistryDefaults, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/state.rs:106
  struct skillet_mcp::project::RegistrySection, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/project.rs:148
  struct skillet_mcp::state::RegistryAuth, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/state.rs:121
  struct skillet_mcp::config::RegistriesConfig, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/config.rs:129
  struct skillet_mcp::trust::TrustedRegistry, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/trust.rs:40

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field registry of struct SkilletToml, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/project.rs:34
  field registry of struct PinnedSkill, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/trust.rs:53
  field registry_path of struct SkillEntry, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/state.rs:218
  field registries of struct SkilletConfig, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/config.rs:17
  field registry_paths of struct AppState, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/state.rs:19
  field trusted_registries of struct TrustState, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/trust.rs:62
  field registry of struct InstalledSkill, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/manifest.rs:27
  field registry of struct InstallOptions, previously in file /tmp/.tmpkfY8lA/skillet-mcp/src/install.rs:21
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0] - 2026-03-02

### Bug Fixes

- Scope uninstall to current project directory ([#173](https://github.com/joshrotenberg/skillet/pull/173))

### Refactor

- Design v2 -- remove publishing, simplify trust, rename registry to repo ([#171](https://github.com/joshrotenberg/skillet/pull/171))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).