### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - 2026-03-17
+
+### Bug Fixes
+
+- Show quickstart help when running skillet interactively ([#174](https://github.com/joshrotenberg/skillet/pull/174))
+- Scope `skillet list` to current project and global by default ([#176](https://github.com/joshrotenberg/skillet/pull/176))
+- Soften trust warning on install ([#177](https://github.com/joshrotenberg/skillet/pull/177))
+- Implicit serve when --repo/--remote/--http flags are provided ([#201](https://github.com/joshrotenberg/skillet/pull/201))
+- Add [source] prefer = main to prevent tag checkout on self ([#209](https://github.com/joshrotenberg/skillet/pull/209))
+
+### Documentation
+
+- Quote glob in README search examples ([#178](https://github.com/joshrotenberg/skillet/pull/178))
+- Update all docs and skills for prompt server architecture ([#200](https://github.com/joshrotenberg/skillet/pull/200))
+
+### Features
+
+- Hint at skill-repos on empty search results ([#179](https://github.com/joshrotenberg/skillet/pull/179))
+- Rewrite as skill network + MCP prompt server ([#196](https://github.com/joshrotenberg/skillet/pull/196))
+- Harden suggest graph with safety limits and trust tiers ([#197](https://github.com/joshrotenberg/skillet/pull/197))
+- Release model resolution for skill repos ([#198](https://github.com/joshrotenberg/skillet/pull/198))
+- Cache tiering, provenance polish, and public instance groundwork ([#199](https://github.com/joshrotenberg/skillet/pull/199))
+- Prompt arguments for section filtering, clean up dead suggest URLs ([#207](https://github.com/joshrotenberg/skillet/pull/207))
+- Auto-detect skills/ directory, expand suggest list ([#208](https://github.com/joshrotenberg/skillet/pull/208))
+
+### Refactor
+
+- Rename registry/ to skills/ ([#181](https://github.com/joshrotenberg/skillet/pull/181))
+- Replace static test fixtures with dynamic generation ([#183](https://github.com/joshrotenberg/skillet/pull/183))
+- Remove registry terminology, add [[suggest]] for discovery ([#184](https://github.com/joshrotenberg/skillet/pull/184))
+- Remove dead integrity/content_hash fields and stale URIs ([#202](https://github.com/joshrotenberg/skillet/pull/202))
+
+
+
 ## [0.4.0] - 2026-03-02
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "skillet-mcp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillet-mcp"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.90"
 description = "MCP-native skill discovery for AI agents"


### PR DESCRIPTION



## 🤖 New release

* `skillet-mcp`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `skillet-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SkilletToml.suggest in /tmp/.tmpQJz3vk/skillet/src/project.rs:34
  field SkilletToml.source in /tmp/.tmpQJz3vk/skillet/src/project.rs:38
  field CacheConfig.suggest_ttl in /tmp/.tmpQJz3vk/skillet/src/config.rs:106
  field SkillEntry.trust_tier in /tmp/.tmpQJz3vk/skillet/src/state.rs:173
  field SkillEntry.discovered_via in /tmp/.tmpQJz3vk/skillet/src/state.rs:177
  field ReposConfig.follow_suggestions in /tmp/.tmpQJz3vk/skillet/src/config.rs:127
  field ReposConfig.suggest_depth in /tmp/.tmpQJz3vk/skillet/src/config.rs:130
  field SkillSummary.trust_tier in /tmp/.tmpQJz3vk/skillet/src/state.rs:323
  field SkillSummary.discovered_via in /tmp/.tmpQJz3vk/skillet/src/state.rs:326
  field SkilletConfig.suggest in /tmp/.tmpQJz3vk/skillet/src/config.rs:20
  field SkilletConfig.source in /tmp/.tmpQJz3vk/skillet/src/config.rs:23

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum skillet_mcp::trust::TrustTier, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/trust.rs:18
  enum skillet_mcp::safety::Severity, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/safety.rs:20
  enum skillet_mcp::manifest::IntegrityStatus, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/manifest.rs:36
  enum skillet_mcp::config::InstallTarget, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/config.rs:137
  enum skillet_mcp::trust::AuditStatus, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/trust.rs:65

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant SkillSource::Embedded 2 -> 1 in /tmp/.tmpQJz3vk/skillet/src/state.rs:107

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Error::ManifestRead, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/error.rs:31
  variant Error::ManifestParse, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/error.rs:36
  variant Error::ManifestWrite, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/error.rs:41
  variant Error::ManifestSerialize, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/error.rs:46
  variant Error::TrustRead, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/error.rs:50
  variant Error::TrustParse, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/error.rs:55
  variant Error::TrustWrite, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/error.rs:60
  variant Error::TrustSerialize, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/error.rs:65
  variant Error::CreateDir, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/error.rs:69
  variant Error::WriteFile, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/error.rs:74
  variant Error::CurrentDir, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/error.rs:79
  variant Error::ManifestFormatError, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/error.rs:83
  variant Error::ManifestMissingComposite, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/error.rs:85
  variant Error::Validation, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/error.rs:101
  variant SkillSource::Local, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/state.rs:107

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function skillet_mcp::manifest::save_to, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/manifest.rs:77
  function skillet_mcp::install::install_skill, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/install.rs:35
  function skillet_mcp::trust::audit_has_problems, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/trust.rs:292
  function skillet_mcp::integrity::format_manifest, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/integrity.rs:106
  function skillet_mcp::trust::load_from, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/trust.rs:110
  function skillet_mcp::config::resolve_targets, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/config.rs:245
  function skillet_mcp::integrity::sha256_hex, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/integrity.rs:24
  function skillet_mcp::manifest::load_from, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/manifest.rs:56
  function skillet_mcp::validate::validate_skillpack_lenient, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/validate.rs:157
  function skillet_mcp::trust::check_trust, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/trust.rs:193
  function skillet_mcp::safety::scan, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/safety.rs:180
  function skillet_mcp::install::uninstall_skill, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/install.rs:152
  function skillet_mcp::safety::truncate_match, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/safety.rs:290
  function skillet_mcp::trust::trust_path, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/trust.rs:100
  function skillet_mcp::integrity::verify, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/integrity.rs:119
  function skillet_mcp::version::check_and_notify, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/version.rs:33
  function skillet_mcp::manifest::manifest_path, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/manifest.rs:46
  function skillet_mcp::trust::save, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/trust.rs:126
  function skillet_mcp::discover::discover_local_skills, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/discover.rs:19
  function skillet_mcp::integrity::compute_hashes, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/integrity.rs:35
  function skillet_mcp::manifest::save, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/manifest.rs:72
  function skillet_mcp::trust::audit, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/trust.rs:239
  function skillet_mcp::integrity::parse_manifest, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/integrity.rs:70
  function skillet_mcp::trust::load, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/trust.rs:105
  function skillet_mcp::manifest::load, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/manifest.rs:51
  function skillet_mcp::validate::validate_skillpack, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/validate.rs:38
  function skillet_mcp::trust::save_to, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/trust.rs:131
  function skillet_mcp::config::generate_default_config, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/config.rs:291

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  skillet_mcp::repo::load_repos now takes 5 parameters instead of 4, in /tmp/.tmpQJz3vk/skillet/src/repo.rs:87

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod skillet_mcp::validate, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/validate.rs:1
  mod skillet_mcp::version, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/version.rs:1
  mod skillet_mcp::install, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/install.rs:1
  mod skillet_mcp::discover, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/discover.rs:1
  mod skillet_mcp::integrity, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/integrity.rs:1
  mod skillet_mcp::manifest, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/manifest.rs:1
  mod skillet_mcp::trust, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/trust.rs:1
  mod skillet_mcp::safety, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/safety.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  ALL_TARGETS in file /tmp/.tmpxSdsz8/skillet-mcp/src/config.rs:147

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct skillet_mcp::config::TrustConfig, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/config.rs:69
  struct skillet_mcp::config::InstallConfig, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/config.rs:113
  struct skillet_mcp::manifest::InstalledSkill, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/manifest.rs:23
  struct skillet_mcp::install::InstallOptions, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/install.rs:16
  struct skillet_mcp::config::SafetyConfig, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/config.rs:61
  struct skillet_mcp::install::UninstallOptions, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/install.rs:146
  struct skillet_mcp::integrity::ContentHashes, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/integrity.rs:16
  struct skillet_mcp::safety::SafetyReport, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/safety.rs:55
  struct skillet_mcp::manifest::InstalledManifest, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/manifest.rs:16
  struct skillet_mcp::safety::SafetyFinding, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/safety.rs:38
  struct skillet_mcp::trust::PinnedSkill, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/trust.rs:36
  struct skillet_mcp::trust::TrustCheck, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/trust.rs:55
  struct skillet_mcp::install::InstallResult, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/install.rs:25
  struct skillet_mcp::validate::ValidationResult, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/validate.rs:17
  struct skillet_mcp::install::UninstallResult, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/install.rs:134
  struct skillet_mcp::trust::AuditResult, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/trust.rs:89
  struct skillet_mcp::trust::TrustState, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/trust.rs:48

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field install of struct SkilletConfig, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/config.rs:16
  field safety of struct SkilletConfig, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/config.rs:20
  field trust of struct SkilletConfig, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/config.rs:21
  field content_hash of struct SkillVersion, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/state.rs:183
  field integrity_ok of struct SkillVersion, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/state.rs:186
  field discover_local of struct ServerConfig, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/config.rs:41
  field content_hash of struct SkillSummary, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/state.rs:304
  field integrity of struct SkillSummary, previously in file /tmp/.tmpxSdsz8/skillet-mcp/src/state.rs:307
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0] - 2026-03-17

### Bug Fixes

- Show quickstart help when running skillet interactively ([#174](https://github.com/joshrotenberg/skillet/pull/174))
- Scope `skillet list` to current project and global by default ([#176](https://github.com/joshrotenberg/skillet/pull/176))
- Soften trust warning on install ([#177](https://github.com/joshrotenberg/skillet/pull/177))
- Implicit serve when --repo/--remote/--http flags are provided ([#201](https://github.com/joshrotenberg/skillet/pull/201))
- Add [source] prefer = main to prevent tag checkout on self ([#209](https://github.com/joshrotenberg/skillet/pull/209))

### Documentation

- Quote glob in README search examples ([#178](https://github.com/joshrotenberg/skillet/pull/178))
- Update all docs and skills for prompt server architecture ([#200](https://github.com/joshrotenberg/skillet/pull/200))

### Features

- Hint at skill-repos on empty search results ([#179](https://github.com/joshrotenberg/skillet/pull/179))
- Rewrite as skill network + MCP prompt server ([#196](https://github.com/joshrotenberg/skillet/pull/196))
- Harden suggest graph with safety limits and trust tiers ([#197](https://github.com/joshrotenberg/skillet/pull/197))
- Release model resolution for skill repos ([#198](https://github.com/joshrotenberg/skillet/pull/198))
- Cache tiering, provenance polish, and public instance groundwork ([#199](https://github.com/joshrotenberg/skillet/pull/199))
- Prompt arguments for section filtering, clean up dead suggest URLs ([#207](https://github.com/joshrotenberg/skillet/pull/207))
- Auto-detect skills/ directory, expand suggest list ([#208](https://github.com/joshrotenberg/skillet/pull/208))

### Refactor

- Rename registry/ to skills/ ([#181](https://github.com/joshrotenberg/skillet/pull/181))
- Replace static test fixtures with dynamic generation ([#183](https://github.com/joshrotenberg/skillet/pull/183))
- Remove registry terminology, add [[suggest]] for discovery ([#184](https://github.com/joshrotenberg/skillet/pull/184))
- Remove dead integrity/content_hash fields and stale URIs ([#202](https://github.com/joshrotenberg/skillet/pull/202))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).