### PR TITLE
fix: scope `skillet list` to current project by default

### DIFF
--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process::ExitCode;
 
 use skillet_mcp::{config, manifest, repo, search, state};
@@ -305,7 +306,7 @@ pub(crate) fn run_info(args: InfoArgs) -> ExitCode {
 }
 
 /// Run the `list` subcommand.
-pub(crate) fn run_list(_args: ListArgs) -> ExitCode {
+pub(crate) fn run_list(args: ListArgs) -> ExitCode {
     let installed_manifest = match manifest::load() {
         Ok(m) => m,
         Err(e) => {
@@ -314,15 +315,31 @@ pub(crate) fn run_list(_args: ListArgs) -> ExitCode {
         }
     };
 
-    if installed_manifest.skills.is_empty() {
-        println!("No skills installed.");
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let home = PathBuf::from(std::env::var("HOME").unwrap_or_default());
+
+    let skills: Vec<&manifest::InstalledSkill> = installed_manifest
+        .skills
+        .iter()
+        .filter(|s| {
+            args.all || s.installed_to.starts_with(&home) || s.installed_to.starts_with(&cwd)
+        })
+        .collect();
+
+    if skills.is_empty() {
+        if installed_manifest.skills.is_empty() {
+            println!("No skills installed.");
+        } else {
+            println!("No skills installed in this scope.");
+            println!("Use --all to see all installations.");
+        }
         return ExitCode::SUCCESS;
     }
 
     // Group by (owner, name)
     let mut groups: std::collections::BTreeMap<(String, String), Vec<&manifest::InstalledSkill>> =
         std::collections::BTreeMap::new();
-    for skill in &installed_manifest.skills {
+    for skill in &skills {
         groups
             .entry((skill.owner.clone(), skill.name.clone()))
             .or_default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,9 +247,9 @@ struct InfoArgs {
 
 #[derive(clap::Args, Debug)]
 struct ListArgs {
-    /// List installed skills (default behavior)
-    #[arg(long, default_value_t = true)]
-    installed: bool,
+    /// Show all installations, including those outside the current project
+    #[arg(long)]
+    all: bool,
 }
 
 #[derive(clap::Args, Debug)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -577,6 +577,63 @@ fn repo_list_empty() {
         .stdout(predicate::str::contains("No repos configured"));
 }
 
+// ── List scoping (#164) ──────────────────────────────────────
+
+#[test]
+fn list_scoped_hides_other_projects() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let home = tmp.path().join("home");
+    let project_a = tmp.path().join("project-a");
+    let project_b = tmp.path().join("project-b");
+    std::fs::create_dir_all(&home).expect("create home");
+    std::fs::create_dir_all(&project_a).expect("create project-a");
+    std::fs::create_dir_all(&project_b).expect("create project-b");
+
+    // Install a skill from project-a
+    skillet()
+        .args(["install", "joshrotenberg/rust-dev", "--repo"])
+        .arg(test_repo())
+        .args(["--target", "agents"])
+        .env("HOME", &home)
+        .current_dir(&project_a)
+        .assert()
+        .success();
+
+    // Install a different skill from project-b
+    skillet()
+        .args(["install", "acme/python-dev", "--repo"])
+        .arg(test_repo())
+        .args(["--target", "agents"])
+        .env("HOME", &home)
+        .current_dir(&project_b)
+        .assert()
+        .success();
+
+    // List from project-a should only show project-a's skill
+    skillet()
+        .args(["list"])
+        .env("HOME", &home)
+        .current_dir(&project_a)
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("joshrotenberg/rust-dev")
+                .and(predicate::str::contains("acme/python-dev").not()),
+        );
+
+    // List --all from project-a should show both
+    skillet()
+        .args(["list", "--all"])
+        .env("HOME", &home)
+        .current_dir(&project_a)
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("joshrotenberg/rust-dev")
+                .and(predicate::str::contains("acme/python-dev")),
+        );
+}
+
 // ── npm-style repo tests ─────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- Scope `skillet list` to show only global (`$HOME`) and current-project (`cwd`) installations by default, matching the pattern from #173
- Replace unused `--installed` flag with `--all` to show every manifest entry regardless of directory
- Hint at `--all` when entries exist but are filtered out of the current scope

Closes #164

## Test plan

- [x] New `list_scoped_hides_other_projects` integration test: installs skills into two project directories, verifies scoped list from project-a hides project-b's skill, and `--all` shows both
- [x] Existing `list_shows_installed_skill` and `list_empty_when_nothing_installed` tests still pass
- [x] `cargo clippy`, `cargo fmt`, full test suite green