### PR TITLE
fix: soften trust warning on install

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -175,14 +175,22 @@ pub(crate) fn run_install(args: InstallArgs) -> ExitCode {
                     }
                 }
                 _ => {
-                    // "warn" (default) -- explicit guidance
-                    eprintln!(
-                        "Warning: {reason}\n\
-                         To verify before installing:\n\
-                         \n  skillet info {owner}/{name}\n\
-                         \n  skillet trust pin {owner}/{name}\n",
-                        reason = trust_check.reason,
-                    );
+                    // "warn" (default) -- brief tip, detailed guidance with --verbose
+                    if args.verbose {
+                        eprintln!(
+                            "Warning: {reason}\n\
+                             To verify before installing:\n\
+                             \n  skillet info {owner}/{name}\n\
+                             \n  skillet trust pin {owner}/{name}\n",
+                            reason = trust_check.reason,
+                        );
+                    } else {
+                        eprintln!(
+                            "Tip: {owner}/{name} is not yet pinned. \
+                             It will be auto-pinned after install.\n  \
+                             Run `skillet trust --help` to learn more.",
+                        );
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,10 @@ struct InstallArgs {
     #[arg(long)]
     require_trusted: bool,
 
+    /// Show detailed trust information during install
+    #[arg(long, short)]
+    verbose: bool,
+
     #[command(flatten)]
     repos: RepoArgs,
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -980,3 +980,23 @@ fn info_official_skill() {
                 .and(predicate::str::contains("consumer")),
         );
 }
+
+// ── Install trust warning ────────────────────────────────────────────
+
+#[test]
+fn install_trust_warning_is_soft() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let home = tmp.path().join("home");
+    std::fs::create_dir_all(&home).expect("create home");
+
+    skillet()
+        .args(["install", "joshrotenberg/rust-dev", "--repo"])
+        .arg(test_repo())
+        .args(["--target", "agents"])
+        .env("HOME", &home)
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Tip:").and(predicate::str::contains("Warning:").not()))
+        .stdout(predicate::str::contains("Installed joshrotenberg/rust-dev"));
+}


### PR DESCRIPTION
## Summary

- Replace the multi-line `Warning:` on first install of an unpinned skill with a brief `Tip:` message
- Add `--verbose` / `-v` flag to `skillet install` to show the original detailed trust guidance
- Since auto-pin is on by default, the warning only fires on the very first install of each skill

Closes #163

## Test plan

- [x] New `install_trust_warning_is_soft` test verifies stderr contains `Tip:` and not `Warning:`
- [x] Existing `install_writes_files` and `list_shows_installed_skill` tests still pass
- [x] All 87 tests pass (56 CLI + 12 HTTP + 19 scenarios)
- [x] `cargo clippy` and `cargo fmt` clean