### PR TITLE
feat: hint at skill-repos on empty search results

### DIFF
--- a/src/tools/search_skills.rs
+++ b/src/tools/search_skills.rs
@@ -98,7 +98,9 @@ pub fn build(state: Arc<AppState>) -> Tool {
 
                 if results.is_empty() {
                     return Ok(CallToolResult::text(format!(
-                        "No skills found matching '{}'.",
+                        "No skills found matching '{}'.\n\n\
+                         Tip: use `info_skill` with `owner: \"skillet\"`, `name: \"skill-repos\"` \
+                         to see external repositories that may have relevant skills.",
                         input.query
                     )));
                 }


### PR DESCRIPTION
## Summary

- When `search_skills` returns no matches, append a tip directing the agent to `skillet/skill-repos` for external repository suggestions
- Enables the discovery chain: empty search -> agent reads skill-repos -> suggests adding a remote

## Test plan

- [x] Existing "No skills found" assertions in `cli.rs` and `scenarios.rs` still pass (substring match)
- [x] All 87 tests pass
- [x] `cargo clippy` and `cargo fmt` clean