### PR TITLE
feat: harden suggest graph with safety limits and trust tiers

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -232,6 +232,8 @@ mod tests {
             name: "test-skill".to_string(),
             repo_path: None,
             source: Default::default(),
+            trust_tier: Default::default(),
+            discovered_via: Vec::new(),
             versions: vec![SkillVersion {
                 version: "0.1.0".to_string(),
                 metadata: SkillMetadata {
@@ -470,6 +472,8 @@ mod tests {
             name: "with-files".to_string(),
             repo_path: None,
             source: Default::default(),
+            trust_tier: Default::default(),
+            discovered_via: Vec::new(),
             versions: vec![SkillVersion {
                 version: "1.0.0".to_string(),
                 metadata: SkillMetadata {

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -284,7 +284,17 @@ pub(crate) fn run_info(args: InfoArgs) -> ExitCode {
 
     // Repo path for nested skills
     if let Some(ref rpath) = entry.repo_path {
-        println!("  repo path ......... {rpath}");
+        println!("  repo path ............. {rpath}");
+    }
+
+    // Trust tier and provenance
+    if entry.trust_tier != skillet_mcp::state::TrustTier::Direct {
+        let via = if entry.discovered_via.is_empty() {
+            String::new()
+        } else {
+            format!(" (via {})", entry.discovered_via.join(" -> "))
+        };
+        println!("  trust ................. {}{via}", entry.trust_tier);
     }
 
     ExitCode::SUCCESS

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,46 @@ pub struct SkilletConfig {
     pub repos: ReposConfig,
     pub cache: CacheConfig,
     pub server: ServerConfig,
+    pub suggest: SuggestConfig,
+}
+
+/// `[suggest]` section: controls `[[suggest]]` graph traversal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SuggestConfig {
+    /// Whether to follow suggestions at all.
+    pub enabled: bool,
+    /// Maximum BFS depth for following suggestion links.
+    pub max_depth: u32,
+    /// Maximum suggestions to follow from any single repo.
+    pub max_per_repo: usize,
+    /// Total maximum repos to clone via suggestions.
+    pub max_repos: usize,
+    /// Timeout for each git clone operation (e.g. "30s").
+    pub clone_timeout: String,
+    /// How long to remember a failed URL before retrying (e.g. "1h").
+    pub negative_cache_ttl: String,
+    /// Glob patterns for allowed URLs (empty = allow all).
+    #[serde(default)]
+    pub allow: Vec<String>,
+    /// Glob patterns for blocked URLs (checked before cloning).
+    #[serde(default)]
+    pub block: Vec<String>,
+}
+
+impl Default for SuggestConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_depth: 2,
+            max_per_repo: 5,
+            max_repos: 20,
+            clone_timeout: "30s".to_string(),
+            negative_cache_ttl: "1h".to_string(),
+            allow: Vec::new(),
+            block: Vec::new(),
+        }
+    }
 }
 
 /// `[server]` section: MCP server tool/resource exposure control.

--- a/src/git.rs
+++ b/src/git.rs
@@ -5,6 +5,7 @@
 
 use std::path::Path;
 use std::process::Command;
+use std::time::Duration;
 
 use crate::error::Error;
 
@@ -82,6 +83,66 @@ pub fn clone_or_pull(url: &str, target: &Path) -> crate::error::Result<()> {
     } else {
         tracing::info!(url, path = %target.display(), "Cloning remote repo");
         clone(url, target)
+    }
+}
+
+/// Clone or pull with a timeout for git HTTP operations.
+///
+/// Sets `GIT_HTTP_LOW_SPEED_LIMIT` and `GIT_HTTP_LOW_SPEED_TIME` environment
+/// variables to make git itself abort slow connections. This avoids needing
+/// process kill logic and works for both clone and pull.
+///
+/// Note: these env vars only affect HTTP(S) transports; SSH clones use
+/// the SSH client's own timeout configuration.
+pub fn clone_or_pull_with_timeout(
+    url: &str,
+    target: &Path,
+    timeout: Duration,
+) -> crate::error::Result<()> {
+    let timeout_secs = timeout.as_secs().max(1).to_string();
+
+    if target.join(".git").exists() {
+        tracing::info!(path = %target.display(), "Pulling existing clone (with timeout)");
+        let output = Command::new("git")
+            .args(["pull"])
+            .current_dir(target)
+            .env("GIT_HTTP_LOW_SPEED_LIMIT", "1000")
+            .env("GIT_HTTP_LOW_SPEED_TIME", &timeout_secs)
+            .output()
+            .map_err(|e| Error::Io {
+                context: "failed to run git pull".to_string(),
+                source: e,
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return Err(Error::Git {
+                operation: "pull".to_string(),
+                stderr,
+            });
+        }
+        Ok(())
+    } else {
+        tracing::info!(url, path = %target.display(), "Cloning remote repo (with timeout)");
+        let output = Command::new("git")
+            .args(["clone", "--depth", "1", url])
+            .arg(target)
+            .env("GIT_HTTP_LOW_SPEED_LIMIT", "1000")
+            .env("GIT_HTTP_LOW_SPEED_TIME", &timeout_secs)
+            .output()
+            .map_err(|e| Error::Io {
+                context: "failed to run git clone".to_string(),
+                source: e,
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return Err(Error::Git {
+                operation: format!("clone {url}"),
+                stderr,
+            });
+        }
+        Ok(())
     }
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -405,6 +405,8 @@ fn load_skill(owner: &str, name: &str, dir: &Path) -> crate::error::Result<Skill
         repo_path: None,
         versions,
         source: SkillSource::default(),
+        trust_tier: Default::default(),
+        discovered_via: Vec::new(),
     })
 }
 
@@ -775,6 +777,8 @@ description = "A skill collection"
             name: "test".to_string(),
             repo_path: None,
             source: SkillSource::default(),
+            trust_tier: Default::default(),
+            discovered_via: Vec::new(),
             versions: vec![
                 SkillVersion {
                     version: "1.0.0".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod repo;
 pub mod scaffold;
 pub mod search;
 pub mod state;
+pub mod suggest;
 
 #[cfg(any(test, feature = "testutil"))]
 pub mod testutil;

--- a/src/main.rs
+++ b/src/main.rs
@@ -439,25 +439,28 @@ async fn run_serve_inner(args: ServeArgs) -> Result<(), tower_mcp::BoxError> {
     }
 
     // Follow [[suggest]] entries from loaded repos
-    if !args.no_suggest && cli_config.repos.follow_suggestions {
-        let suggest_depth = cli_config.repos.suggest_depth;
+    if !args.no_suggest && cli_config.suggest.enabled {
         let cache_enabled = cli_config.cache.enabled;
         let cache_ttl = if cache_enabled {
             repo::parse_duration(&cli_config.cache.ttl).unwrap_or(Duration::from_secs(300))
         } else {
             Duration::ZERO
         };
-        let visited: std::collections::HashSet<String> = args.remote.iter().cloned().collect();
-        let seed_paths = repo_paths.clone();
-        repo::follow_suggestions_serve(
-            &seed_paths,
+        let seed_urls: Vec<String> = args.remote.clone();
+        let mut walker = skillet_mcp::suggest::SuggestWalker::new(
+            &cli_config.suggest,
             &cache_base,
             cache_enabled,
             cache_ttl,
+            &seed_urls,
+        );
+        let seed_paths = repo_paths.clone();
+        walker.walk(
+            &seed_paths,
             &mut merged_index,
             &mut repo_paths,
-            visited,
-            suggest_depth,
+            cli_config.suggest.max_depth,
+            vec![],
         );
     }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -664,6 +664,8 @@ fn build_embedded_entry(
             content_hash: None,
             integrity_ok: None,
         }],
+        trust_tier: Default::default(),
+        discovered_via: Vec::new(),
     })
 }
 
@@ -776,6 +778,8 @@ fn build_embedded_entry_from_dir(
             content_hash: None,
             integrity_ok: None,
         }],
+        trust_tier: Default::default(),
+        discovered_via: Vec::new(),
     })
 }
 

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -77,6 +77,8 @@ mod tests {
             name: name.to_string(),
             repo_path: None,
             source: SkillSource::Repo,
+            trust_tier: Default::default(),
+            discovered_via: Vec::new(),
             versions: vec![SkillVersion {
                 version: "1.0.0".to_string(),
                 metadata: SkillMetadata {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,6 +1,5 @@
 //! Repo management: initialization, loading, and utility functions.
 
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -8,7 +7,7 @@ use crate::cache::{self, RepoSource};
 use crate::config::SkilletConfig;
 use crate::error::Error;
 use crate::state::SkillIndex;
-use crate::{git, index, project};
+use crate::{git, index};
 
 /// The official default repo, used when no repos are configured.
 pub const DEFAULT_REPO_URL: &str = "https://github.com/joshrotenberg/skillet.git";
@@ -188,152 +187,26 @@ pub fn load_repos(
     }
 
     // Follow [[suggest]] entries from loaded repos
-    if !no_suggest && config.repos.follow_suggestions {
-        let depth = config.repos.suggest_depth;
-        let visited: HashSet<String> = remote_urls.iter().map(|u| u.to_string()).collect();
-        follow_suggestions_serve(
-            &repo_paths,
+    if !no_suggest && config.suggest.enabled {
+        let seed_urls: Vec<String> = remote_urls.iter().map(|u| u.to_string()).collect();
+        let mut walker = crate::suggest::SuggestWalker::new(
+            &config.suggest,
             &cache_base,
             cache_enabled,
             cache_ttl,
+            &seed_urls,
+        );
+        let seed_paths = repo_paths.clone();
+        walker.walk(
+            &seed_paths,
             &mut merged,
-            &mut repo_paths.clone(),
-            visited,
-            depth,
+            &mut repo_paths,
+            config.suggest.max_depth,
+            vec![],
         );
     }
 
     Ok((merged, repo_paths))
-}
-
-/// Walk up from a skills subdirectory to find the repo root containing `skillet.toml`.
-///
-/// Checks the given path and its ancestors (up to 5 levels) for a `skillet.toml`.
-fn find_repo_root(skill_path: &Path) -> Option<PathBuf> {
-    let mut current = skill_path.to_path_buf();
-    for _ in 0..5 {
-        if current.join("skillet.toml").is_file() {
-            return Some(current);
-        }
-        if !current.pop() {
-            break;
-        }
-    }
-    None
-}
-
-/// Follow `[[suggest]]` entries from loaded repos.
-///
-/// For each repo path, reads `skillet.toml` (walking up from the skills
-/// subdirectory if needed), collects `[[suggest]]` entries not yet visited,
-/// clones/indexes each, and merges into the index. Recurses up to `depth`.
-///
-/// Called by both `load_repos` (CLI path) and `run_serve_inner` (MCP path).
-#[allow(clippy::too_many_arguments)]
-pub fn follow_suggestions_serve(
-    repo_paths: &[PathBuf],
-    cache_base: &Path,
-    cache_enabled: bool,
-    cache_ttl: Duration,
-    merged: &mut SkillIndex,
-    all_paths: &mut Vec<PathBuf>,
-    mut visited: HashSet<String>,
-    depth: u32,
-) {
-    if depth == 0 {
-        return;
-    }
-
-    let mut new_suggestions = Vec::new();
-
-    for path in repo_paths {
-        // Find the repo root (skillet.toml might be above the skills subdir)
-        let root = find_repo_root(path).or_else(|| {
-            // If the path has a parent, try that too
-            path.parent().and_then(find_repo_root)
-        });
-
-        let root = match root {
-            Some(r) => r,
-            None => continue,
-        };
-
-        let manifest = match project::load_skillet_toml(&root) {
-            Ok(Some(m)) => m,
-            _ => continue,
-        };
-
-        for entry in &manifest.suggest {
-            if entry.url.is_empty() || visited.contains(&entry.url) {
-                continue;
-            }
-            visited.insert(entry.url.clone());
-
-            tracing::debug!(
-                url = %entry.url,
-                description = entry.description.as_deref().unwrap_or(""),
-                "Following suggestion"
-            );
-
-            let target = cache_dir_for_url(cache_base, &entry.url);
-            if let Some(parent) = target.parent()
-                && let Err(e) = std::fs::create_dir_all(parent)
-            {
-                tracing::warn!(url = %entry.url, error = %e, "Failed to create cache dir for suggestion");
-                continue;
-            }
-
-            if let Err(e) = git::clone_or_pull(&entry.url, &target) {
-                tracing::warn!(url = %entry.url, error = %e, "Failed to clone suggested repo");
-                continue;
-            }
-
-            let skill_path = match &entry.subdir {
-                Some(sub) => target.join(sub),
-                None => target.clone(),
-            };
-
-            let source = RepoSource::Remote {
-                url: entry.url.clone(),
-                checkout: target,
-            };
-
-            if cache_enabled && let Some(idx) = cache::load(&source, cache_ttl) {
-                merged.merge(idx);
-                all_paths.push(skill_path.clone());
-                new_suggestions.push(skill_path);
-                continue;
-            }
-
-            match index::load_index(&skill_path) {
-                Ok(idx) => {
-                    if cache_enabled {
-                        cache::write(&source, &idx);
-                    }
-                    merged.merge(idx);
-                    all_paths.push(skill_path.clone());
-                    new_suggestions.push(skill_path);
-                }
-                Err(e) => {
-                    tracing::warn!(url = %entry.url, error = %e, "Failed to index suggested repo");
-                }
-            }
-        }
-    }
-
-    // Recurse for the newly added repos
-    if !new_suggestions.is_empty() && depth > 1 {
-        follow_suggestions_serve(
-            &new_suggestions,
-            cache_base,
-            cache_enabled,
-            cache_ttl,
-            merged,
-            all_paths,
-            visited,
-            depth - 1,
-        );
-    }
 }
 
 /// Identify a repo for manifest entries.
@@ -451,31 +324,6 @@ mod tests {
 
         let id = repo_id(&cached_path, std::slice::from_ref(&url));
         assert_eq!(id, url);
-    }
-
-    #[test]
-    fn test_find_repo_root_at_root() {
-        let tmp = tempfile::tempdir().unwrap();
-        std::fs::write(tmp.path().join("skillet.toml"), "[project]\n").unwrap();
-        let found = find_repo_root(tmp.path());
-        assert_eq!(found, Some(tmp.path().to_path_buf()));
-    }
-
-    #[test]
-    fn test_find_repo_root_from_subdir() {
-        let tmp = tempfile::tempdir().unwrap();
-        std::fs::write(tmp.path().join("skillet.toml"), "[project]\n").unwrap();
-        let skills = tmp.path().join("skills");
-        std::fs::create_dir_all(&skills).unwrap();
-        let found = find_repo_root(&skills);
-        assert_eq!(found, Some(tmp.path().to_path_buf()));
-    }
-
-    #[test]
-    fn test_find_repo_root_not_found() {
-        let tmp = tempfile::tempdir().unwrap();
-        let found = find_repo_root(tmp.path());
-        assert!(found.is_none());
     }
 
     #[test]

--- a/src/search.rs
+++ b/src/search.rs
@@ -126,6 +126,8 @@ mod tests {
             name: name.to_string(),
             repo_path: None,
             source: Default::default(),
+            trust_tier: Default::default(),
+            discovered_via: Vec::new(),
             versions: vec![SkillVersion {
                 version: "1.0.0".to_string(),
                 metadata: SkillMetadata {

--- a/src/state.rs
+++ b/src/state.rs
@@ -138,6 +138,28 @@ impl SkillSource {
     }
 }
 
+/// How a skill was discovered, determining its trust level.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TrustTier {
+    /// From a directly configured repo (depth 0)
+    #[default]
+    Direct,
+    /// From a repo that a direct repo suggested (depth 1)
+    Suggested,
+    /// From a repo at depth >= 2 in the suggest graph
+    Transitive,
+}
+
+impl std::fmt::Display for TrustTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Direct => f.write_str("direct"),
+            Self::Suggested => f.write_str("suggested"),
+            Self::Transitive => f.write_str("transitive"),
+        }
+    }
+}
+
 /// A skill with all its versions
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SkillEntry {
@@ -154,6 +176,13 @@ pub struct SkillEntry {
     pub versions: Vec<SkillVersion>,
     #[serde(default)]
     pub source: SkillSource,
+    /// Trust level based on how the skill was discovered in the suggest graph.
+    #[serde(default)]
+    pub trust_tier: TrustTier,
+    /// Provenance chain: repo URLs traversed to discover this skill.
+    /// Empty for directly configured repos.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub discovered_via: Vec<String>,
 }
 
 impl SkillEntry {
@@ -308,6 +337,12 @@ pub struct SkillSummary {
     /// Source label for display (e.g. "local (claude)")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_label: Option<String>,
+    /// Trust tier (omitted for "direct")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trust_tier: Option<String>,
+    /// Provenance chain of repo URLs
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub discovered_via: Vec<String>,
 }
 
 impl SkillSummary {
@@ -348,6 +383,11 @@ impl SkillSummary {
             content_hash: v.content_hash.clone(),
             integrity,
             source_label: entry.source.label(),
+            trust_tier: match entry.trust_tier {
+                TrustTier::Direct => None,
+                ref t => Some(t.to_string()),
+            },
+            discovered_via: entry.discovered_via.clone(),
         })
     }
 }
@@ -392,6 +432,8 @@ mod tests {
             repo_path: None,
             versions,
             source: SkillSource::Repo,
+            trust_tier: Default::default(),
+            discovered_via: Vec::new(),
         }
     }
 

--- a/src/suggest.rs
+++ b/src/suggest.rs
@@ -1,0 +1,545 @@
+//! Suggest graph walker with safety limits, URL canonicalization, and trust tiers.
+//!
+//! The `[[suggest]]` mechanism in `skillet.toml` lets repos point to other repos,
+//! forming a decentralized discovery graph. This module walks that graph with
+//! configurable safety limits (fan-out, total repos, clone timeout, negative caching)
+//! and stamps each discovered skill with a hop-based trust tier.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use crate::cache::{self, RepoSource};
+use crate::config::SuggestConfig;
+use crate::state::{SkillIndex, TrustTier};
+use crate::{git, index, project};
+
+/// Normalize a git URL for deduplication.
+///
+/// - Converts `git@host:owner/repo.git` to `https://host/owner/repo`
+/// - Strips trailing `.git`
+/// - Lowercases the host
+/// - Strips trailing slashes
+pub fn canonicalize_url(url: &str) -> String {
+    let url = url.trim();
+
+    // Convert SSH-style URLs: git@github.com:owner/repo -> https://github.com/owner/repo
+    let url = if let Some(rest) = url.strip_prefix("git@") {
+        if let Some((host, path)) = rest.split_once(':') {
+            format!("https://{host}/{path}")
+        } else {
+            url.to_string()
+        }
+    } else {
+        url.to_string()
+    };
+
+    // Strip trailing .git
+    let url = url.strip_suffix(".git").unwrap_or(&url).to_string();
+
+    // Strip trailing slashes
+    let url = url.trim_end_matches('/').to_string();
+
+    // Lowercase the host portion
+    if let Some(rest) = url.strip_prefix("https://") {
+        if let Some(slash) = rest.find('/') {
+            let (host, path) = rest.split_at(slash);
+            format!("https://{}{path}", host.to_lowercase())
+        } else {
+            format!("https://{}", rest.to_lowercase())
+        }
+    } else if let Some(rest) = url.strip_prefix("http://") {
+        if let Some(slash) = rest.find('/') {
+            let (host, path) = rest.split_at(slash);
+            format!("http://{}{path}", host.to_lowercase())
+        } else {
+            format!("http://{}", rest.to_lowercase())
+        }
+    } else {
+        url
+    }
+}
+
+/// Check if a URL matches any pattern in a list.
+///
+/// Patterns support simple prefix matching with `*` as a wildcard suffix.
+/// Examples: `github.com/tokio-rs/*`, `github.com/*`, `*.example.com`.
+fn url_matches_patterns(url: &str, patterns: &[String]) -> bool {
+    let canonical = canonicalize_url(url);
+    // Strip scheme for matching
+    let bare = canonical
+        .strip_prefix("https://")
+        .or_else(|| canonical.strip_prefix("http://"))
+        .unwrap_or(&canonical);
+
+    patterns.iter().any(|pattern| {
+        let pattern = pattern
+            .strip_prefix("https://")
+            .or_else(|| pattern.strip_prefix("http://"))
+            .unwrap_or(pattern);
+
+        if let Some(prefix) = pattern.strip_suffix('*') {
+            bare.starts_with(prefix)
+        } else if let Some(suffix) = pattern.strip_prefix('*') {
+            bare.ends_with(suffix)
+        } else {
+            bare == pattern
+        }
+    })
+}
+
+/// In-memory cache of URLs that failed to clone.
+struct NegativeCache {
+    failures: HashMap<String, Instant>,
+    ttl: Duration,
+}
+
+impl NegativeCache {
+    fn new(ttl: Duration) -> Self {
+        Self {
+            failures: HashMap::new(),
+            ttl,
+        }
+    }
+
+    /// Returns true if this URL failed recently and should be skipped.
+    fn is_blocked(&self, canonical_url: &str) -> bool {
+        if let Some(failed_at) = self.failures.get(canonical_url) {
+            failed_at.elapsed() < self.ttl
+        } else {
+            false
+        }
+    }
+
+    /// Record a clone failure for this URL.
+    fn record_failure(&mut self, canonical_url: &str) {
+        self.failures
+            .insert(canonical_url.to_string(), Instant::now());
+    }
+}
+
+/// BFS walker for the `[[suggest]]` graph with safety limits.
+pub struct SuggestWalker {
+    config: SuggestConfig,
+    cache_base: PathBuf,
+    cache_enabled: bool,
+    cache_ttl: Duration,
+    visited: HashSet<String>,
+    negative_cache: NegativeCache,
+    total_cloned: usize,
+}
+
+impl SuggestWalker {
+    /// Create a new walker, seeding the visited set with explicitly configured URLs.
+    pub fn new(
+        config: &SuggestConfig,
+        cache_base: &Path,
+        cache_enabled: bool,
+        cache_ttl: Duration,
+        seed_urls: &[String],
+    ) -> Self {
+        let neg_ttl = crate::repo::parse_duration(&config.negative_cache_ttl)
+            .unwrap_or(Duration::from_secs(3600));
+
+        let visited: HashSet<String> = seed_urls.iter().map(|u| canonicalize_url(u)).collect();
+
+        Self {
+            config: config.clone(),
+            cache_base: cache_base.to_path_buf(),
+            cache_enabled,
+            cache_ttl,
+            visited,
+            negative_cache: NegativeCache::new(neg_ttl),
+            total_cloned: 0,
+        }
+    }
+
+    /// Walk the suggest graph starting from the given repo paths.
+    ///
+    /// Discovers `[[suggest]]` entries in each repo's `skillet.toml`, clones them,
+    /// indexes their skills, and merges into `merged`. Recurses up to `depth` levels.
+    ///
+    /// Each discovered skill is stamped with the appropriate `TrustTier` and
+    /// `discovered_via` provenance chain.
+    pub fn walk(
+        &mut self,
+        repo_paths: &[PathBuf],
+        merged: &mut SkillIndex,
+        all_paths: &mut Vec<PathBuf>,
+        depth: u32,
+        provenance: Vec<String>,
+    ) {
+        if depth == 0 || !self.config.enabled {
+            return;
+        }
+
+        if self.total_cloned >= self.config.max_repos {
+            tracing::info!(
+                max = self.config.max_repos,
+                "Suggest graph: total repo cap reached"
+            );
+            return;
+        }
+
+        let trust_tier = match depth {
+            d if d >= self.config.max_depth => TrustTier::Transitive,
+            d if d == self.config.max_depth - 1 => TrustTier::Transitive,
+            _ => TrustTier::Suggested,
+        };
+
+        let clone_timeout = crate::repo::parse_duration(&self.config.clone_timeout)
+            .unwrap_or(Duration::from_secs(30));
+
+        let mut new_suggestions = Vec::new();
+
+        for path in repo_paths {
+            let root = find_repo_root(path).or_else(|| path.parent().and_then(find_repo_root));
+
+            let root = match root {
+                Some(r) => r,
+                None => continue,
+            };
+
+            let manifest = match project::load_skillet_toml(&root) {
+                Ok(Some(m)) => m,
+                _ => continue,
+            };
+
+            let mut followed_from_this_repo = 0;
+
+            for entry in &manifest.suggest {
+                // Per-repo fan-out limit
+                if followed_from_this_repo >= self.config.max_per_repo {
+                    tracing::debug!(
+                        repo = %root.display(),
+                        max = self.config.max_per_repo,
+                        "Suggest graph: per-repo fan-out limit reached"
+                    );
+                    break;
+                }
+
+                // Total repo cap
+                if self.total_cloned >= self.config.max_repos {
+                    tracing::info!(
+                        max = self.config.max_repos,
+                        "Suggest graph: total repo cap reached"
+                    );
+                    return;
+                }
+
+                if entry.url.is_empty() {
+                    continue;
+                }
+
+                let canonical = canonicalize_url(&entry.url);
+
+                // Already visited?
+                if self.visited.contains(&canonical) {
+                    continue;
+                }
+                self.visited.insert(canonical.clone());
+
+                // Negative cache: skip recently failed URLs
+                if self.negative_cache.is_blocked(&canonical) {
+                    tracing::debug!(url = %entry.url, "Skipping negatively cached URL");
+                    continue;
+                }
+
+                // Blocklist check
+                if !self.config.block.is_empty()
+                    && url_matches_patterns(&entry.url, &self.config.block)
+                {
+                    tracing::debug!(url = %entry.url, "Blocked by suggest blocklist");
+                    continue;
+                }
+
+                // Allowlist check (if configured, URL must match)
+                if !self.config.allow.is_empty()
+                    && !url_matches_patterns(&entry.url, &self.config.allow)
+                {
+                    tracing::debug!(url = %entry.url, "Not in suggest allowlist, skipping");
+                    continue;
+                }
+
+                tracing::debug!(
+                    url = %entry.url,
+                    description = entry.description.as_deref().unwrap_or(""),
+                    depth,
+                    "Following suggestion"
+                );
+
+                let target = crate::repo::cache_dir_for_url(&self.cache_base, &entry.url);
+                if let Some(parent) = target.parent()
+                    && let Err(e) = std::fs::create_dir_all(parent)
+                {
+                    tracing::warn!(url = %entry.url, error = %e, "Failed to create cache dir");
+                    continue;
+                }
+
+                if let Err(e) = git::clone_or_pull_with_timeout(&entry.url, &target, clone_timeout)
+                {
+                    tracing::warn!(url = %entry.url, error = %e, "Failed to clone suggested repo");
+                    self.negative_cache.record_failure(&canonical);
+                    continue;
+                }
+
+                self.total_cloned += 1;
+                followed_from_this_repo += 1;
+
+                let skill_path = match &entry.subdir {
+                    Some(sub) => target.join(sub),
+                    None => target.clone(),
+                };
+
+                let source = RepoSource::Remote {
+                    url: entry.url.clone(),
+                    checkout: target,
+                };
+
+                let mut entry_provenance = provenance.clone();
+                entry_provenance.push(entry.url.clone());
+
+                if self.cache_enabled
+                    && let Some(mut idx) = cache::load(&source, self.cache_ttl)
+                {
+                    stamp_trust(&mut idx, &trust_tier, &entry_provenance);
+                    merged.merge(idx);
+                    all_paths.push(skill_path.clone());
+                    new_suggestions.push(skill_path);
+                    continue;
+                }
+
+                match index::load_index(&skill_path) {
+                    Ok(mut idx) => {
+                        if self.cache_enabled {
+                            cache::write(&source, &idx);
+                        }
+                        stamp_trust(&mut idx, &trust_tier, &entry_provenance);
+                        merged.merge(idx);
+                        all_paths.push(skill_path.clone());
+                        new_suggestions.push(skill_path);
+                    }
+                    Err(e) => {
+                        tracing::warn!(url = %entry.url, error = %e, "Failed to index suggested repo");
+                        self.negative_cache.record_failure(&canonical);
+                    }
+                }
+            }
+        }
+
+        // Recurse for the newly added repos
+        if !new_suggestions.is_empty() && depth > 1 {
+            self.walk(&new_suggestions, merged, all_paths, depth - 1, provenance);
+        }
+    }
+}
+
+/// Stamp trust tier and provenance on all entries in an index.
+fn stamp_trust(index: &mut SkillIndex, tier: &TrustTier, provenance: &[String]) {
+    for entry in index.skills.values_mut() {
+        entry.trust_tier = tier.clone();
+        entry.discovered_via = provenance.to_vec();
+    }
+}
+
+/// Walk up from a skills subdirectory to find the repo root containing `skillet.toml`.
+fn find_repo_root(skill_path: &Path) -> Option<PathBuf> {
+    let mut current = skill_path.to_path_buf();
+    for _ in 0..5 {
+        if current.join("skillet.toml").is_file() {
+            return Some(current);
+        }
+        if !current.pop() {
+            break;
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- canonicalize_url --
+
+    #[test]
+    fn canonical_https_with_git_suffix() {
+        assert_eq!(
+            canonicalize_url("https://github.com/owner/repo.git"),
+            "https://github.com/owner/repo"
+        );
+    }
+
+    #[test]
+    fn canonical_https_without_git_suffix() {
+        assert_eq!(
+            canonicalize_url("https://github.com/owner/repo"),
+            "https://github.com/owner/repo"
+        );
+    }
+
+    #[test]
+    fn canonical_ssh_to_https() {
+        assert_eq!(
+            canonicalize_url("git@github.com:owner/repo.git"),
+            "https://github.com/owner/repo"
+        );
+    }
+
+    #[test]
+    fn canonical_ssh_no_git_suffix() {
+        assert_eq!(
+            canonicalize_url("git@github.com:owner/repo"),
+            "https://github.com/owner/repo"
+        );
+    }
+
+    #[test]
+    fn canonical_lowercases_host() {
+        assert_eq!(
+            canonicalize_url("https://GitHub.COM/Owner/Repo.git"),
+            "https://github.com/Owner/Repo"
+        );
+    }
+
+    #[test]
+    fn canonical_strips_trailing_slashes() {
+        assert_eq!(
+            canonicalize_url("https://github.com/owner/repo/"),
+            "https://github.com/owner/repo"
+        );
+    }
+
+    #[test]
+    fn canonical_trims_whitespace() {
+        assert_eq!(
+            canonicalize_url("  https://github.com/owner/repo.git  "),
+            "https://github.com/owner/repo"
+        );
+    }
+
+    // -- url_matches_patterns --
+
+    #[test]
+    fn pattern_prefix_wildcard() {
+        assert!(url_matches_patterns(
+            "https://github.com/tokio-rs/skills.git",
+            &["github.com/tokio-rs/*".to_string()]
+        ));
+    }
+
+    #[test]
+    fn pattern_no_match() {
+        assert!(!url_matches_patterns(
+            "https://github.com/other/repo.git",
+            &["github.com/tokio-rs/*".to_string()]
+        ));
+    }
+
+    #[test]
+    fn pattern_exact_match() {
+        assert!(url_matches_patterns(
+            "https://github.com/owner/repo.git",
+            &["github.com/owner/repo".to_string()]
+        ));
+    }
+
+    #[test]
+    fn pattern_suffix_wildcard() {
+        assert!(url_matches_patterns(
+            "https://skills.example.com/repo",
+            &["*.example.com/repo".to_string()]
+        ));
+    }
+
+    // -- NegativeCache --
+
+    #[test]
+    fn negative_cache_blocks_recent_failure() {
+        let mut cache = NegativeCache::new(Duration::from_secs(3600));
+        let url = "https://github.com/broken/repo";
+        cache.record_failure(url);
+        assert!(cache.is_blocked(url));
+    }
+
+    #[test]
+    fn negative_cache_allows_unknown_url() {
+        let cache = NegativeCache::new(Duration::from_secs(3600));
+        assert!(!cache.is_blocked("https://github.com/unknown/repo"));
+    }
+
+    #[test]
+    fn negative_cache_expires() {
+        let mut cache = NegativeCache::new(Duration::from_millis(1));
+        cache.record_failure("https://github.com/broken/repo");
+        std::thread::sleep(Duration::from_millis(10));
+        assert!(!cache.is_blocked("https://github.com/broken/repo"));
+    }
+
+    // -- find_repo_root --
+
+    #[test]
+    fn find_repo_root_at_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("skillet.toml"), "[project]\n").unwrap();
+        let found = find_repo_root(tmp.path());
+        assert_eq!(found, Some(tmp.path().to_path_buf()));
+    }
+
+    #[test]
+    fn find_repo_root_from_subdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("skillet.toml"), "[project]\n").unwrap();
+        let skills = tmp.path().join("skills");
+        std::fs::create_dir_all(&skills).unwrap();
+        let found = find_repo_root(&skills);
+        assert_eq!(found, Some(tmp.path().to_path_buf()));
+    }
+
+    #[test]
+    fn find_repo_root_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let found = find_repo_root(tmp.path());
+        assert!(found.is_none());
+    }
+
+    // -- SuggestWalker construction --
+
+    #[test]
+    fn walker_seeds_visited_with_canonical_urls() {
+        let config = SuggestConfig::default();
+        let walker = SuggestWalker::new(
+            &config,
+            Path::new("/tmp"),
+            false,
+            Duration::ZERO,
+            &[
+                "https://github.com/a/b.git".to_string(),
+                "git@github.com:c/d.git".to_string(),
+            ],
+        );
+
+        assert!(walker.visited.contains("https://github.com/a/b"));
+        assert!(walker.visited.contains("https://github.com/c/d"));
+    }
+
+    // -- Aliased URLs dedup --
+
+    #[test]
+    fn canonical_deduplicates_aliases() {
+        let urls = [
+            "https://github.com/org/repo",
+            "https://github.com/org/repo.git",
+            "git@github.com:org/repo.git",
+            "https://GitHub.COM/org/repo.git",
+            "https://github.com/org/repo/",
+        ];
+        let canonical: HashSet<String> = urls.iter().map(|u| canonicalize_url(u)).collect();
+        assert_eq!(
+            canonical.len(),
+            1,
+            "all aliases should canonicalize to the same URL"
+        );
+        assert!(canonical.contains("https://github.com/org/repo"));
+    }
+}


### PR DESCRIPTION
## Summary

- Extract suggest graph walking from `repo.rs` into dedicated `src/suggest.rs` with `SuggestWalker`
- Add URL canonicalization: SSH -> HTTPS, strip `.git`, lowercase host, dedup aliased URLs
- Add safety limits: `max_per_repo` (5), `max_repos` (20), `clone_timeout` (30s), negative caching (1h TTL)
- Add URL allowlist/blocklist for controlling which repos can be discovered
- Add `TrustTier` enum (`Direct`/`Suggested`/`Transitive`) and `discovered_via` provenance chain on `SkillEntry`
- Expose trust tier in CLI `info` output and MCP tool responses via `SkillSummary`
- New `[suggest]` config section replaces `repos.follow_suggestions`/`repos.suggest_depth`

## Test plan

- [x] 221 tests passing (174 lib, 26 cli, 12 http, 9 scenarios)
- [x] `cargo fmt`, `cargo clippy` clean
- [x] URL canonicalization tests: HTTPS, SSH, mixed case, trailing slashes, aliased URLs dedup
- [x] Negative cache expiry tests
- [x] Pattern matching tests for allow/block lists
- [x] SuggestWalker seeding with canonical URLs
- [x] find_repo_root tests (moved from repo.rs)

Closes #192, #193
Part of #187