### PR TITLE
feat: release model resolution for skill repos

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,27 @@ pub struct SkilletConfig {
     pub cache: CacheConfig,
     pub server: ServerConfig,
     pub suggest: SuggestConfig,
+    /// Consumer-side version pinning for specific repos.
+    #[serde(default)]
+    pub source: Vec<SourcePin>,
+}
+
+/// A `[[source]]` entry: consumer-side version pin for a specific repo.
+///
+/// ```toml
+/// [[source]]
+/// repo = "github.com/someone/skills"
+/// version = "v2.1.0"
+/// ```
+///
+/// If `version` is absent, skillet auto-detects (latest release or main).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SourcePin {
+    /// Repo identifier (canonical URL without scheme, e.g. "github.com/owner/repo").
+    pub repo: String,
+    /// Pinned git ref (tag, branch, or commit). None = auto-detect.
+    #[serde(default)]
+    pub version: Option<String>,
 }
 
 /// `[suggest]` section: controls `[[suggest]]` graph traversal.

--- a/src/git.rs
+++ b/src/git.rs
@@ -75,6 +75,81 @@ pub fn head(repo_path: &Path) -> crate::error::Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+/// List tags in a local clone, sorted by version (latest last).
+///
+/// Returns tag names (e.g. `["v0.1.0", "v0.2.0", "v1.0.0"]`).
+/// Returns an empty vec if the repo has no tags.
+pub fn list_tags(repo_path: &Path) -> crate::error::Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["tag", "--list", "--sort=version:refname"])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| Error::Io {
+            context: "failed to run git tag".to_string(),
+            source: e,
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(Error::Git {
+            operation: "tag --list".to_string(),
+            stderr,
+        });
+    }
+
+    let tags: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect();
+
+    Ok(tags)
+}
+
+/// Fetch tags from the remote (needed for shallow clones).
+pub fn fetch_tags(repo_path: &Path) -> crate::error::Result<()> {
+    let output = Command::new("git")
+        .args(["fetch", "--tags", "--quiet"])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| Error::Io {
+            context: "failed to run git fetch --tags".to_string(),
+            source: e,
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(Error::Git {
+            operation: "fetch --tags".to_string(),
+            stderr,
+        });
+    }
+
+    Ok(())
+}
+
+/// Checkout a specific ref (tag, branch, or commit).
+pub fn checkout(repo_path: &Path, ref_name: &str) -> crate::error::Result<()> {
+    let output = Command::new("git")
+        .args(["checkout", ref_name, "--quiet"])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| Error::Io {
+            context: format!("failed to run git checkout {ref_name}"),
+            source: e,
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(Error::Git {
+            operation: format!("checkout {ref_name}"),
+            stderr,
+        });
+    }
+
+    Ok(())
+}
+
 /// Clone if the target doesn't exist, otherwise pull.
 pub fn clone_or_pull(url: &str, target: &Path) -> crate::error::Result<()> {
     if target.join(".git").exists() {
@@ -147,7 +222,7 @@ pub fn clone_or_pull_with_timeout(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use std::process::Command;
     use tempfile::TempDir;
@@ -161,6 +236,11 @@ mod tests {
             .output()
             .unwrap();
         dir
+    }
+
+    /// Public version for use by other test modules.
+    pub(crate) fn make_repo_with_commit_pub() -> TempDir {
+        make_repo_with_commit()
     }
 
     /// Create a git repo with an initial commit and return its temp directory.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod index;
 pub mod project;
 pub mod prompts;
 pub mod repo;
+pub mod resolve;
 pub mod scaffold;
 pub mod search;
 pub mod state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -375,6 +375,7 @@ async fn run_serve(args: ServeArgs) -> ExitCode {
 
 async fn run_serve_inner(args: ServeArgs) -> Result<(), tower_mcp::BoxError> {
     let cache_base = args.cache_dir.clone().unwrap_or_else(default_cache_dir);
+    let cli_config = config::load_config().unwrap_or_default();
     let mut repo_paths = Vec::new();
 
     // Resolve local repos
@@ -394,6 +395,13 @@ async fn run_serve_inner(args: ServeArgs) -> Result<(), tower_mcp::BoxError> {
             std::fs::create_dir_all(parent)?;
         }
         git::clone_or_pull(url, &target)?;
+
+        // Resolve release model: checkout appropriate tag/ref
+        if let Err(e) = skillet_mcp::resolve::resolve_and_checkout(&target, url, &cli_config.source)
+        {
+            tracing::warn!(url, error = %e, "Failed to resolve release ref, using default branch");
+        }
+
         let path = match &args.subdir {
             Some(sub) => target.join(sub),
             None => target,
@@ -421,9 +429,6 @@ async fn run_serve_inner(args: ServeArgs) -> Result<(), tower_mcp::BoxError> {
     }
 
     tracing::info!(count = repo_paths.len(), "Starting skillet server");
-
-    // Load CLI config early (used for capabilities)
-    let cli_config = config::load_config().unwrap_or_default();
 
     // Load and merge all repos
     let mut merged_index = state::SkillIndex::default();
@@ -453,6 +458,7 @@ async fn run_serve_inner(args: ServeArgs) -> Result<(), tower_mcp::BoxError> {
             cache_enabled,
             cache_ttl,
             &seed_urls,
+            cli_config.source.clone(),
         );
         let seed_paths = repo_paths.clone();
         walker.walk(

--- a/src/project.rs
+++ b/src/project.rs
@@ -32,6 +32,26 @@ pub struct SkilletToml {
     /// Suggested repos for decentralized discovery
     #[serde(default)]
     pub suggest: Vec<SuggestEntry>,
+
+    /// Author-side source preference for release model
+    #[serde(default)]
+    pub source: Option<SourceSection>,
+}
+
+/// `[source]` section in `skillet.toml`: author-side release model preference.
+///
+/// Controls which git ref skillet should use when serving this repo's skills.
+/// If absent, skillet auto-detects: latest release tag if available, otherwise main.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SourceSection {
+    /// Preferred ref strategy: `"release"`, `"main"`, or a glob like `"tag:v*"`.
+    /// Default: `"release"` (use latest release tag, fall back to main).
+    #[serde(default = "default_prefer")]
+    pub prefer: String,
+}
+
+fn default_prefer() -> String {
+    "release".to_string()
 }
 
 /// A suggested repo that this repo recommends following.

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -162,6 +162,16 @@ pub fn load_repos(
             std::fs::create_dir_all(parent)?;
         }
         git::clone_or_pull(url, &target)?;
+
+        // Resolve release model: checkout appropriate tag/ref
+        if let Err(e) = crate::resolve::resolve_and_checkout(&target, url, &config.source) {
+            tracing::warn!(
+                url,
+                error = %e,
+                "Failed to resolve release ref, using default branch"
+            );
+        }
+
         let path = match subdir {
             Some(sub) => target.join(sub),
             None if *url == DEFAULT_REPO_URL => target.join(DEFAULT_REPO_SUBDIR),
@@ -195,6 +205,7 @@ pub fn load_repos(
             cache_enabled,
             cache_ttl,
             &seed_urls,
+            config.source.clone(),
         );
         let seed_paths = repo_paths.clone();
         walker.walk(

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,0 +1,295 @@
+//! Release model resolution for skill repos.
+//!
+//! Determines which git ref to checkout for a repo based on:
+//! 1. Consumer-side pin (`[[source]]` in config.toml) -- highest priority
+//! 2. Author-side preference (`[source]` in skillet.toml)
+//! 3. Auto-detection: latest release tag if available, otherwise default branch
+//!
+//! After clone/pull, call `resolve_and_checkout` to switch to the correct ref.
+
+use std::path::Path;
+
+use crate::config::SourcePin;
+use crate::git;
+use crate::project;
+use crate::suggest::canonicalize_url;
+
+/// Resolve which git ref to use and checkout that ref.
+///
+/// Priority:
+/// 1. Consumer pin from config (exact match on canonical URL)
+/// 2. Author preference from `[source].prefer` in skillet.toml
+/// 3. Auto-detect: latest release tag, or stay on default branch
+///
+/// Returns the ref that was checked out, or `None` if staying on default branch.
+pub fn resolve_and_checkout(
+    repo_path: &Path,
+    url: &str,
+    consumer_pins: &[SourcePin],
+) -> crate::error::Result<Option<String>> {
+    // 1. Check consumer-side pin
+    if let Some(pin) = find_consumer_pin(url, consumer_pins) {
+        tracing::info!(url, version = %pin, "Using consumer-pinned version");
+        git::fetch_tags(repo_path)?;
+        git::checkout(repo_path, &pin)?;
+        return Ok(Some(pin));
+    }
+
+    // 2. Check author-side preference
+    let author_prefer = load_author_preference(repo_path);
+
+    match author_prefer.as_deref() {
+        Some("main") => {
+            tracing::debug!(url, "Author prefers main, staying on default branch");
+            Ok(None)
+        }
+        Some(pref) if pref.starts_with("tag:") => {
+            let pattern = &pref[4..];
+            tracing::debug!(url, pattern, "Author prefers tag pattern");
+            git::fetch_tags(repo_path)?;
+            let tags = git::list_tags(repo_path)?;
+            if let Some(tag) = find_matching_tag(&tags, pattern) {
+                tracing::info!(url, tag = %tag, "Checking out author-preferred tag");
+                git::checkout(repo_path, &tag)?;
+                Ok(Some(tag))
+            } else {
+                tracing::debug!(
+                    url,
+                    pattern,
+                    "No tags match pattern, staying on default branch"
+                );
+                Ok(None)
+            }
+        }
+        // "release" or None (default) -- auto-detect
+        _ => auto_detect(repo_path, url),
+    }
+}
+
+/// Auto-detect: if the repo has release-style tags (vX.Y.Z), checkout the latest one.
+fn auto_detect(repo_path: &Path, url: &str) -> crate::error::Result<Option<String>> {
+    // Fetch tags (shallow clones don't have them by default)
+    if let Err(e) = git::fetch_tags(repo_path) {
+        tracing::debug!(url, error = %e, "Failed to fetch tags, staying on default branch");
+        return Ok(None);
+    }
+
+    let tags = git::list_tags(repo_path)?;
+    if tags.is_empty() {
+        tracing::debug!(url, "No tags found, staying on default branch");
+        return Ok(None);
+    }
+
+    // Look for the latest semver-style tag (v1.2.3 or 1.2.3)
+    let release_tag = tags.iter().rev().find(|t| is_release_tag(t));
+
+    if let Some(tag) = release_tag {
+        tracing::info!(url, tag = %tag, "Auto-detected latest release tag");
+        git::checkout(repo_path, tag)?;
+        Ok(Some(tag.clone()))
+    } else {
+        tracing::debug!(
+            url,
+            "No release-style tags found, staying on default branch"
+        );
+        Ok(None)
+    }
+}
+
+/// Check if a tag looks like a release version (v1.2.3, 1.2.3, 2026.01.01, etc).
+fn is_release_tag(tag: &str) -> bool {
+    let s = tag.strip_prefix('v').unwrap_or(tag);
+    // Must start with a digit and contain at least one dot
+    s.starts_with(|c: char| c.is_ascii_digit()) && s.contains('.')
+}
+
+/// Find a consumer-side pin for a URL.
+fn find_consumer_pin(url: &str, pins: &[SourcePin]) -> Option<String> {
+    let canonical = canonicalize_url(url);
+    // Strip scheme for matching (pins use bare "github.com/owner/repo")
+    let bare = canonical
+        .strip_prefix("https://")
+        .or_else(|| canonical.strip_prefix("http://"))
+        .unwrap_or(&canonical);
+
+    pins.iter()
+        .find(|p| {
+            let pin_bare = p
+                .repo
+                .strip_prefix("https://")
+                .or_else(|| p.repo.strip_prefix("http://"))
+                .unwrap_or(&p.repo);
+            pin_bare == bare
+        })
+        .and_then(|p| p.version.clone())
+}
+
+/// Load author preference from the repo's skillet.toml.
+fn load_author_preference(repo_path: &Path) -> Option<String> {
+    let manifest = project::load_skillet_toml(repo_path).ok()??;
+    manifest.source.map(|s| s.prefer)
+}
+
+/// Find the last tag matching a glob pattern (e.g. "v*", "v2.*").
+fn find_matching_tag(tags: &[String], pattern: &str) -> Option<String> {
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        tags.iter().rev().find(|t| t.starts_with(prefix)).cloned()
+    } else {
+        // Exact match
+        tags.iter().find(|t| t.as_str() == pattern).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::SourcePin;
+
+    #[test]
+    fn is_release_tag_semver() {
+        assert!(is_release_tag("v1.0.0"));
+        assert!(is_release_tag("v0.2.3"));
+        assert!(is_release_tag("1.0.0"));
+        assert!(is_release_tag("2026.01.01"));
+    }
+
+    #[test]
+    fn is_release_tag_non_release() {
+        assert!(!is_release_tag("latest"));
+        assert!(!is_release_tag("nightly"));
+        assert!(!is_release_tag("main"));
+        assert!(!is_release_tag("v")); // no digits after v
+    }
+
+    #[test]
+    fn is_release_tag_no_dot() {
+        assert!(!is_release_tag("v1")); // needs a dot
+        assert!(!is_release_tag("123")); // no dot
+    }
+
+    #[test]
+    fn consumer_pin_matches_canonical() {
+        let pins = vec![SourcePin {
+            repo: "github.com/owner/repo".to_string(),
+            version: Some("v1.0.0".to_string()),
+        }];
+
+        // HTTPS with .git
+        assert_eq!(
+            find_consumer_pin("https://github.com/owner/repo.git", &pins),
+            Some("v1.0.0".to_string())
+        );
+        // SSH
+        assert_eq!(
+            find_consumer_pin("git@github.com:owner/repo.git", &pins),
+            Some("v1.0.0".to_string())
+        );
+        // No match
+        assert_eq!(
+            find_consumer_pin("https://github.com/other/repo.git", &pins),
+            None
+        );
+    }
+
+    #[test]
+    fn consumer_pin_no_version_returns_none() {
+        let pins = vec![SourcePin {
+            repo: "github.com/owner/repo".to_string(),
+            version: None,
+        }];
+        assert_eq!(
+            find_consumer_pin("https://github.com/owner/repo.git", &pins),
+            None
+        );
+    }
+
+    #[test]
+    fn find_matching_tag_glob() {
+        let tags = vec![
+            "v0.1.0".to_string(),
+            "v0.2.0".to_string(),
+            "v1.0.0".to_string(),
+        ];
+        assert_eq!(find_matching_tag(&tags, "v*"), Some("v1.0.0".to_string()));
+        assert_eq!(find_matching_tag(&tags, "v0.*"), Some("v0.2.0".to_string()));
+    }
+
+    #[test]
+    fn find_matching_tag_exact() {
+        let tags = vec!["v1.0.0".to_string(), "v2.0.0".to_string()];
+        assert_eq!(
+            find_matching_tag(&tags, "v1.0.0"),
+            Some("v1.0.0".to_string())
+        );
+        assert_eq!(find_matching_tag(&tags, "v3.0.0"), None);
+    }
+
+    #[test]
+    fn find_matching_tag_no_match() {
+        let tags = vec!["v1.0.0".to_string()];
+        assert_eq!(find_matching_tag(&tags, "v2.*"), None);
+    }
+
+    // Integration tests with actual git repos
+
+    #[test]
+    fn resolve_repo_without_tags_stays_on_default() {
+        let repo = crate::git::tests::make_repo_with_commit_pub();
+        let result = resolve_and_checkout(repo.path(), "file:///test", &[]).unwrap();
+        assert_eq!(result, None, "repo without tags should stay on default");
+    }
+
+    #[test]
+    fn resolve_repo_with_release_tag() {
+        let repo = crate::git::tests::make_repo_with_commit_pub();
+        // Create a release tag
+        std::process::Command::new("git")
+            .args(["-C", &repo.path().display().to_string(), "tag", "v1.0.0"])
+            .output()
+            .unwrap();
+
+        let result = resolve_and_checkout(repo.path(), "file:///test", &[]).unwrap();
+        assert_eq!(result, Some("v1.0.0".to_string()));
+    }
+
+    #[test]
+    fn resolve_consumer_pin_overrides_tag() {
+        let repo = crate::git::tests::make_repo_with_commit_pub();
+        // Create two tags
+        std::process::Command::new("git")
+            .args(["-C", &repo.path().display().to_string(), "tag", "v1.0.0"])
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["-C", &repo.path().display().to_string(), "tag", "v2.0.0"])
+            .output()
+            .unwrap();
+
+        let pins = vec![SourcePin {
+            repo: "test".to_string(),
+            version: Some("v1.0.0".to_string()),
+        }];
+        // URL matches the pin's repo when canonicalized
+        let result = resolve_and_checkout(repo.path(), "https://test", &pins).unwrap();
+        assert_eq!(result, Some("v1.0.0".to_string()));
+    }
+
+    #[test]
+    fn resolve_author_prefers_main() {
+        let repo = crate::git::tests::make_repo_with_commit_pub();
+        // Create a tag
+        std::process::Command::new("git")
+            .args(["-C", &repo.path().display().to_string(), "tag", "v1.0.0"])
+            .output()
+            .unwrap();
+        // Write skillet.toml with [source] prefer = "main"
+        std::fs::write(
+            repo.path().join("skillet.toml"),
+            "[source]\nprefer = \"main\"\n",
+        )
+        .unwrap();
+
+        let result = resolve_and_checkout(repo.path(), "file:///test", &[]).unwrap();
+        assert_eq!(result, None, "author prefers main, should stay on default");
+    }
+}

--- a/src/suggest.rs
+++ b/src/suggest.rs
@@ -10,9 +10,9 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use crate::cache::{self, RepoSource};
-use crate::config::SuggestConfig;
+use crate::config::{SourcePin, SuggestConfig};
 use crate::state::{SkillIndex, TrustTier};
-use crate::{git, index, project};
+use crate::{git, index, project, resolve};
 
 /// Normalize a git URL for deduplication.
 ///
@@ -127,6 +127,7 @@ pub struct SuggestWalker {
     visited: HashSet<String>,
     negative_cache: NegativeCache,
     total_cloned: usize,
+    consumer_pins: Vec<SourcePin>,
 }
 
 impl SuggestWalker {
@@ -137,6 +138,7 @@ impl SuggestWalker {
         cache_enabled: bool,
         cache_ttl: Duration,
         seed_urls: &[String],
+        consumer_pins: Vec<SourcePin>,
     ) -> Self {
         let neg_ttl = crate::repo::parse_duration(&config.negative_cache_ttl)
             .unwrap_or(Duration::from_secs(3600));
@@ -151,6 +153,7 @@ impl SuggestWalker {
             visited,
             negative_cache: NegativeCache::new(neg_ttl),
             total_cloned: 0,
+            consumer_pins,
         }
     }
 
@@ -281,6 +284,17 @@ impl SuggestWalker {
                     tracing::warn!(url = %entry.url, error = %e, "Failed to clone suggested repo");
                     self.negative_cache.record_failure(&canonical);
                     continue;
+                }
+
+                // Resolve release model: checkout appropriate tag/ref
+                if let Err(e) =
+                    resolve::resolve_and_checkout(&target, &entry.url, &self.consumer_pins)
+                {
+                    tracing::warn!(
+                        url = %entry.url,
+                        error = %e,
+                        "Failed to resolve release ref, using default branch"
+                    );
                 }
 
                 self.total_cloned += 1;
@@ -517,6 +531,7 @@ mod tests {
                 "https://github.com/a/b.git".to_string(),
                 "git@github.com:c/d.git".to_string(),
             ],
+            vec![],
         );
 
         assert!(walker.visited.contains("https://github.com/a/b"));


### PR DESCRIPTION
## Summary

- Add `src/resolve.rs`: determines which git ref to checkout for each repo
- Auto-detection: if repo has semver tags (vX.Y.Z), checkout the latest one; otherwise stay on default branch
- Author-side control via `[source]` in `skillet.toml`: `prefer = "release" | "main" | "tag:v*"`
- Consumer-side pinning via `[[source]]` in `config.toml`: pin specific repos to exact versions
- Priority: consumer pin > author preference > auto-detect
- New git operations: `list_tags()`, `fetch_tags()`, `checkout()`
- Wired into both CLI repo loading and MCP serve path, plus suggest graph walker

## Why

Skills are knowledge, not dependencies. But repos that *do* use proper releases should be respected -- you shouldn't be serving skills from a half-finished commit on main when there's a clean release tag available.

## Test plan

- [x] 233 tests passing (186 lib, 26 cli, 12 http, 9 scenarios)
- [x] `cargo fmt`, `cargo clippy` clean
- [x] Unit tests: `is_release_tag`, `find_consumer_pin`, `find_matching_tag`
- [x] Integration tests with real git repos: no-tags, with-release-tag, consumer-pin-override, author-prefers-main

Closes #194
Part of #187