### PR TITLE
fix: implicit serve when --repo/--remote/--http flags are provided

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,14 +2,14 @@
   "mcpServers": {
     "skillet": {
       "command": "cargo",
-      "args": ["run", "--", "--repo", "test-repo", "--repo", "skills"],
+      "args": ["run", "--", "--repo", "skills"],
       "env": {
         "RUST_LOG": "skillet=debug"
       }
     },
     "skillet-remote": {
       "command": "cargo",
-      "args": ["run", "--", "--remote", "https://github.com/joshrotenberg/skillet.git", "--subdir", "test-repo"],
+      "args": ["run", "--", "--remote", "https://github.com/joshrotenberg/skillet.git", "--subdir", "skills"],
       "env": {
         "RUST_LOG": "skillet=debug"
       }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ testutil = []
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "blocking"] }
 skillet-mcp = { path = ".", features = ["testutil"] }
 
 # The profile that 'dist' will build with

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,7 +218,12 @@ struct RepoRemoveArgs {
 async fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    let interactive_tty = cli.command.is_none() && std::io::stdin().is_terminal();
+    // If the user provided serve-specific args (--repo, --remote, --http),
+    // they intend to serve even from a TTY. Only show help when truly bare.
+    let has_serve_args =
+        !cli.serve.repo.is_empty() || !cli.serve.remote.is_empty() || cli.serve.http.is_some();
+    let interactive_tty =
+        cli.command.is_none() && std::io::stdin().is_terminal() && !has_serve_args;
 
     match cli.command {
         Some(Command::Init(args)) => cli::author::run_init(args),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -303,6 +303,53 @@ fn info_npm_repo_no_frontmatter() {
         );
 }
 
+// -- Implicit serve behavior --
+
+#[test]
+fn repo_flag_triggers_serve_with_http() {
+    // --repo with --http should start the server (not show help).
+    // We test by starting the server and hitting health.
+    let port = {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.local_addr().unwrap().port()
+    };
+
+    let mut child = std::process::Command::new(assert_cmd::cargo::cargo_bin!("skillet"))
+        .args([
+            "--repo",
+            test_repo().to_str().unwrap(),
+            "--http",
+            &format!("127.0.0.1:{port}"),
+            "--log-level",
+            "error",
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn skillet");
+
+    // Poll until server is up or timeout
+    let client = reqwest::blocking::Client::new();
+    let mut ok = false;
+    for _ in 0..50 {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        if client
+            .get(format!("http://127.0.0.1:{port}/health"))
+            .send()
+            .is_ok()
+        {
+            ok = true;
+            break;
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    assert!(
+        ok,
+        "server should start with --repo flag (no explicit serve subcommand)"
+    );
+}
+
 // -- CLI hygiene --
 
 #[test]


### PR DESCRIPTION
## Summary

- Fix: `skillet --repo skills` from a terminal now starts the server instead of showing help
- Fix `.mcp.json` to point at `skills/` (removed `test-repo` reference)
- Add `reqwest/blocking` for integration tests
- Add CLI test verifying implicit serve with `--repo` + `--http`

## Problem

Running `skillet --repo skills` from a terminal showed the interactive help message instead of starting the MCP server. The TTY detection didn't account for serve-specific flags being present.

## Test plan

- [x] 234 tests passing
- [x] `cargo clippy` clean
- [x] New test: `repo_flag_triggers_serve_with_http` verifies the server starts