### PR TITLE
feat: prompt section filtering and clean up dead suggest URLs

### DIFF
--- a/skillet.toml
+++ b/skillet.toml
@@ -17,30 +17,8 @@ path = "skills"
 # Any repo can suggest others; use --no-suggest to opt out.
 
 [[suggest]]
-url = "https://github.com/anthropics/courses.git"
-subdir = "skills"
-description = "Anthropic courses and Claude skills"
-
-[[suggest]]
-url = "https://github.com/anthropics/prompt-eng-interactive-tutorial.git"
-subdir = "skills"
-description = "Anthropic prompt engineering tutorial skills"
-
-[[suggest]]
-url = "https://github.com/vercel-labs/ai-sdk-agents-skills.git"
-description = "Vercel AI SDK agent skills"
-
-[[suggest]]
 url = "https://github.com/firebase/skills.git"
 description = "Firebase agent skills"
-
-[[suggest]]
-url = "https://github.com/supabase-community/supabase-agent-skills.git"
-description = "Supabase agent skills"
-
-[[suggest]]
-url = "https://github.com/google-gemini/agent-skills.git"
-description = "Google Gemini agent skills"
 
 [[suggest]]
 url = "https://github.com/redis/agent-skills.git"
@@ -53,7 +31,3 @@ description = "Callstack agent skills for React Native"
 [[suggest]]
 url = "https://github.com/softaworks/agent-skills.git"
 description = "Softaworks agent skills"
-
-[[suggest]]
-url = "https://github.com/daymade/agent-skills.git"
-description = "Daymade agent skills"

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -1,10 +1,14 @@
 //! Register skills as MCP prompts via tower-mcp's DynamicPromptRegistry.
 //!
 //! Each skill in the index becomes an MCP prompt, namespaced as `owner_skill-name`.
+//! Prompts support an optional `section` argument for filtering by heading.
 //! On index refresh, stale prompts are unregistered and new ones registered,
 //! with a `prompts/list_changed` notification emitted automatically.
 
+use std::collections::HashMap;
+
 use tower_mcp::PromptBuilder;
+use tower_mcp::protocol::{Content, GetPromptResult, PromptMessage, PromptRole};
 use tower_mcp::registry::DynamicPromptRegistry;
 
 use crate::state::SkillIndex;
@@ -12,8 +16,8 @@ use crate::state::SkillIndex;
 /// Register all skills from the index as MCP prompts.
 ///
 /// Prompt names are namespaced as `owner_skill-name` to avoid collisions
-/// across repos. The prompt description comes from skill.toml metadata.
-/// The prompt content is the full SKILL.md text.
+/// across repos. Each prompt accepts an optional `section` argument
+/// to return only a specific section (by heading) of the SKILL.md.
 pub fn register_all(registry: &DynamicPromptRegistry, index: &SkillIndex) {
     for ((owner, name), entry) in &index.skills {
         let Some(latest) = entry.latest() else {
@@ -21,8 +25,8 @@ pub fn register_all(registry: &DynamicPromptRegistry, index: &SkillIndex) {
         };
 
         let prompt_name = format!("{owner}_{name}");
-        let description = &latest.metadata.skill.description;
-        let content = &latest.skill_md;
+        let description = latest.metadata.skill.description.clone();
+        let content = latest.skill_md.clone();
 
         if content.is_empty() {
             tracing::debug!(
@@ -33,13 +37,107 @@ pub fn register_all(registry: &DynamicPromptRegistry, index: &SkillIndex) {
         }
 
         let prompt = PromptBuilder::new(&prompt_name)
-            .description(description)
-            .user_message(content);
+            .description(&description)
+            .optional_arg("section", "Return only a specific section (by heading)")
+            .handler(move |args: HashMap<String, String>| {
+                let content = content.clone();
+                let description = description.clone();
+                async move {
+                    let text = if let Some(section) = args.get("section") {
+                        extract_section(&content, section).unwrap_or_else(|| {
+                            format!(
+                                "Section '{section}' not found. Available sections:\n{}",
+                                list_sections(&content)
+                            )
+                        })
+                    } else {
+                        content
+                    };
+
+                    Ok(GetPromptResult {
+                        description: Some(description),
+                        messages: vec![PromptMessage {
+                            role: PromptRole::User,
+                            content: Content::text(text),
+                            meta: None,
+                        }],
+                        meta: None,
+                    })
+                }
+            })
+            .build();
 
         registry.register(prompt);
 
         tracing::debug!(prompt = %prompt_name, "Registered skill as prompt");
     }
+}
+
+/// Extract a section from markdown by heading.
+///
+/// Matches headings case-insensitively. Returns the heading and everything
+/// until the next heading at the same or higher level, or end of document.
+fn extract_section(content: &str, section_name: &str) -> Option<String> {
+    let section_lower = section_name.to_lowercase();
+    let lines: Vec<&str> = content.lines().collect();
+
+    let mut start = None;
+    let mut start_level = 0;
+
+    for (i, line) in lines.iter().enumerate() {
+        if let Some((level, heading)) = parse_heading(line) {
+            let heading_lower = heading.to_lowercase();
+            if start.is_none()
+                && (heading_lower == section_lower || heading_lower.contains(&section_lower))
+            {
+                start = Some(i);
+                start_level = level;
+            } else if let Some(s) = start {
+                // Found the next heading at same or higher level -- stop
+                if level <= start_level && i > s {
+                    let section: Vec<&str> = lines[s..i].to_vec();
+                    return Some(section.join("\n").trim_end().to_string());
+                }
+            }
+        }
+    }
+
+    // Section extends to end of document
+    start.map(|s| lines[s..].join("\n").trim_end().to_string())
+}
+
+/// List all top-level and second-level headings in markdown.
+fn list_sections(content: &str) -> String {
+    content
+        .lines()
+        .filter_map(|line| {
+            let (level, heading) = parse_heading(line)?;
+            if level <= 3 {
+                let indent = "  ".repeat(level.saturating_sub(1));
+                Some(format!("{indent}- {heading}"))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Parse a markdown heading line, returning (level, text).
+fn parse_heading(line: &str) -> Option<(usize, &str)> {
+    let trimmed = line.trim_start();
+    if !trimmed.starts_with('#') {
+        return None;
+    }
+    let level = trimmed.chars().take_while(|&c| c == '#').count();
+    if level > 6 {
+        return None;
+    }
+    let text = trimmed[level..].trim();
+    if text.is_empty() {
+        return None;
+    }
+    Some((level, text))
 }
 
 /// Sync the prompt registry with a new index.
@@ -69,7 +167,6 @@ pub fn sync(registry: &DynamicPromptRegistry, old_index: &SkillIndex, new_index:
 mod tests {
     use super::*;
     use crate::state::{SkillEntry, SkillMetadata, SkillSource, SkillVersion};
-    use std::collections::HashMap;
 
     fn make_entry(owner: &str, name: &str, description: &str, content: &str) -> SkillEntry {
         SkillEntry {
@@ -118,7 +215,7 @@ mod tests {
         let (router, registry) = tower_mcp::McpRouter::new()
             .server_info("test", "0.1.0")
             .with_dynamic_prompts();
-        let _ = router; // keep alive
+        let _ = router;
 
         let index = make_index(vec![
             make_entry(
@@ -136,10 +233,6 @@ mod tests {
         ]);
 
         register_all(&registry, &index);
-
-        // We can't directly inspect the registry, but we can verify no panics
-        // and that the function completes. Full integration testing happens
-        // via the HTTP/MCP tests.
     }
 
     #[test]
@@ -155,7 +248,6 @@ mod tests {
         ]);
 
         register_all(&registry, &index);
-        // Should not panic on empty content
     }
 
     #[test]
@@ -177,6 +269,90 @@ mod tests {
 
         register_all(&registry, &old_index);
         sync(&registry, &old_index, &new_index);
-        // old-skill should be unregistered, new-skill should be registered
+    }
+
+    // -- Section extraction --
+
+    const SAMPLE_MD: &str = "\
+# Main Title
+
+Introduction text.
+
+## Setup
+
+Setup instructions here.
+
+### Prerequisites
+
+Need these things.
+
+## Usage
+
+How to use it.
+
+## Advanced
+
+Advanced topics.
+
+### Configuration
+
+Config details.
+
+### Troubleshooting
+
+Debug tips.
+";
+
+    #[test]
+    fn extract_exact_section() {
+        let result = extract_section(SAMPLE_MD, "Setup").unwrap();
+        assert!(result.starts_with("## Setup"));
+        assert!(result.contains("Setup instructions"));
+        assert!(result.contains("Prerequisites"));
+        // Should not include Usage
+        assert!(!result.contains("How to use it"));
+    }
+
+    #[test]
+    fn extract_section_case_insensitive() {
+        let result = extract_section(SAMPLE_MD, "setup").unwrap();
+        assert!(result.starts_with("## Setup"));
+    }
+
+    #[test]
+    fn extract_section_partial_match() {
+        let result = extract_section(SAMPLE_MD, "trouble").unwrap();
+        assert!(result.contains("Debug tips"));
+    }
+
+    #[test]
+    fn extract_section_not_found() {
+        assert!(extract_section(SAMPLE_MD, "nonexistent").is_none());
+    }
+
+    #[test]
+    fn extract_last_section() {
+        let result = extract_section(SAMPLE_MD, "Troubleshooting").unwrap();
+        assert!(result.starts_with("### Troubleshooting"));
+        assert!(result.contains("Debug tips"));
+    }
+
+    #[test]
+    fn list_sections_shows_headings() {
+        let sections = list_sections(SAMPLE_MD);
+        assert!(sections.contains("Main Title"));
+        assert!(sections.contains("Setup"));
+        assert!(sections.contains("Usage"));
+        assert!(sections.contains("Prerequisites"));
+    }
+
+    #[test]
+    fn parse_heading_works() {
+        assert_eq!(parse_heading("# Title"), Some((1, "Title")));
+        assert_eq!(parse_heading("## Sub"), Some((2, "Sub")));
+        assert_eq!(parse_heading("### Deep"), Some((3, "Deep")));
+        assert_eq!(parse_heading("not a heading"), None);
+        assert_eq!(parse_heading("#"), None); // no text
+        assert_eq!(parse_heading(""), None);
     }
 }


### PR DESCRIPTION
## Summary

- Prompts now accept an optional `section` argument to return only a specific section by heading
- Case-insensitive, supports partial heading matches
- If section not found, returns list of available sections
- Removed 6 dead/useless `[[suggest]]` entries from skillet.toml (4 repos are 404, 2 Anthropic repos have no skills/ dir)

## Example

```
get_prompt("skills_redis-development", { section: "connection pooling" })
```

Returns just the connection pooling section instead of all 37 rule files worth of content.

## Test plan

- [x] 236 tests passing (7 new section extraction tests)
- [x] `cargo fmt`, `cargo clippy` clean

Closes #203