### PR TITLE
feat: auto-detect skills/ directory, expand suggest list

### DIFF
--- a/skillet.toml
+++ b/skillet.toml
@@ -17,6 +17,15 @@ path = "skills"
 # Any repo can suggest others; use --no-suggest to opt out.
 
 [[suggest]]
+url = "https://github.com/microsoft/skills.git"
+subdir = ".github/plugins"
+description = "Microsoft Azure SDK and dev skills (170 skills)"
+
+[[suggest]]
+url = "https://github.com/TerminalSkills/skills.git"
+description = "Broad skill library covering 800+ tools and frameworks"
+
+[[suggest]]
 url = "https://github.com/firebase/skills.git"
 description = "Firebase agent skills"
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -98,6 +98,64 @@ pub fn load_index(repo_path: &Path) -> crate::error::Result<SkillIndex> {
         return Ok(index);
     }
 
+    // Auto-detect skills/ directory: repos without skillet.toml that have a
+    // skills/<name>/SKILL.md layout (e.g. TerminalSkills/skills, callstack).
+    // Infer owner from git remote or directory name.
+    let skills_dir = repo_path.join("skills");
+    if skills_dir.is_dir() {
+        let skill_dirs = find_skill_dirs(&skills_dir, 0);
+        if !skill_dirs.is_empty() {
+            let git_root = find_git_root(repo_path).unwrap_or(repo_path.to_path_buf());
+            let owner = project::owner_from_git_remote(&git_root).unwrap_or_else(|| {
+                repo_path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string()
+            });
+
+            tracing::info!(
+                owner = %owner,
+                count = skill_dirs.len(),
+                "Auto-detected skills/ directory"
+            );
+
+            for skill_dir in skill_dirs {
+                let skill_name = skill_dir
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string();
+
+                match load_skill(&owner, &skill_name, &skill_dir) {
+                    Ok(entry) => {
+                        let key = (owner.clone(), skill_name.clone());
+                        if let Some(v) = entry.latest()
+                            && let Some(ref c) = v.metadata.skill.classification
+                        {
+                            for cat in &c.categories {
+                                *index.categories.entry(cat.clone()).or_insert(0) += 1;
+                            }
+                        }
+                        index.skills.insert(key, entry);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            owner = %owner,
+                            skill = %skill_name,
+                            error = %e,
+                            "skills/ auto-detect: skipping skill"
+                        );
+                    }
+                }
+            }
+
+            if !index.skills.is_empty() {
+                return Ok(index);
+            }
+        }
+    }
+
     // Iterate over owner directories
     let mut owners: Vec<_> = std::fs::read_dir(repo_path)
         .map_err(|e| Error::FileRead {


### PR DESCRIPTION
## Summary

**Auto-detect skills/ directory**: repos with a `skills/<name>/SKILL.md` layout now work without needing a `skillet.toml` or `--subdir` flag. Owner is inferred from the git remote.

Repo detection priority:
1. `skillet.toml` with `[skill]`/`[skills]` sections
2. `skills/` directory at root (NEW)
3. `owner/name/` nesting
4. Flat `<name>/SKILL.md` fallback

**Expanded suggest list**: added microsoft/skills (170 Azure SDK and dev skills) and TerminalSkills/skills (800+ tools and frameworks). A new user now gets 1,000+ skills on first run from the suggest graph.

## Why

Skillet needs to start useful. The `[[suggest]]` list is just a seed -- once we add GitHub code search (#185), we can back off curated suggestions. For now, casting a wide net means a new user's first `search "*"` is impressive.

## Test plan

- [x] 236 tests passing
- [x] `cargo fmt`, `cargo clippy` clean
- [x] Verified: `--remote TerminalSkills/skills` indexes 863 skills without `--subdir`
- [x] Verified: microsoft/skills works with `subdir = ".github/plugins"`

Partial fix for #204