### PR TITLE
fix: add [source] prefer = main to prevent stale tag checkout

### DIFF
--- a/skillet.toml
+++ b/skillet.toml
@@ -9,6 +9,9 @@ tags = ["mcp", "skills", "ai-agents"]
 name = "Josh Rotenberg"
 github = "joshrotenberg"
 
+[source]
+prefer = "main"
+
 [skills]
 path = "skills"
 


### PR DESCRIPTION
## Problem

Fresh clones of the skillet repo auto-detect the latest release tag (v0.4.0) and check it out. But v0.4.0 predates the redesign -- it has no `skills/` directory, no suggest entries, and the old `registry/` layout. This causes `skillet search` to fail with "repo path does not exist."

## Fix

Add `[source] prefer = "main"` to `skillet.toml`. This tells the release model resolver to stay on the default branch instead of checking out old tags.

Once we cut a v0.5.0 release with the new architecture, we can remove this or switch to `prefer = "release"`.

## Also found

The user's `~/.config/skillet/config.toml` may have stale `repos.remote` entries from the pre-redesign era (e.g. `skillet-registry`). These override the default repo fallback, breaking the suggest graph. Users who upgraded from the old version need to clean their config.