### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1] - 2026-03-18
+
+### Features
+
+- Skill annotations and GitHub repo discovery ([#214](https://github.com/joshrotenberg/skillet/pull/214))
+
+### Miscellaneous Tasks
+
+- Remove [source] prefer = main workaround ([#213](https://github.com/joshrotenberg/skillet/pull/213))
+
+
+
 ## [0.5.0] - 2026-03-17
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "skillet-mcp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillet-mcp"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.90"
 description = "MCP-native skill discovery for AI agents"


### PR DESCRIPTION



## 🤖 New release

* `skillet-mcp`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1] - 2026-03-18

### Features

- Skill annotations and GitHub repo discovery ([#214](https://github.com/joshrotenberg/skillet/pull/214))

### Miscellaneous Tasks

- Remove [source] prefer = main workaround ([#213](https://github.com/joshrotenberg/skillet/pull/213))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).