### PR TITLE
chore: remove [source] prefer = main workaround

### DIFF
--- a/skillet.toml
+++ b/skillet.toml
@@ -9,9 +9,6 @@ tags = ["mcp", "skills", "ai-agents"]
 name = "Josh Rotenberg"
 github = "joshrotenberg"
 
-[source]
-prefer = "main"
-
 [skills]
 path = "skills"
 


### PR DESCRIPTION
v0.5.0 is released. Auto-detect finds the correct tag now.