### PR TITLE
feat: skill annotations and GitHub repo discovery

### DIFF
--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -1,0 +1,126 @@
+//! Persistent skill annotations.
+//!
+//! Agents can attach notes to skills that persist across sessions.
+//! Stored as JSON in `~/.config/skillet/annotations.json`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::config;
+
+/// A single annotation on a skill.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Annotation {
+    /// The note text.
+    pub note: String,
+    /// ISO 8601 timestamp.
+    pub created_at: String,
+}
+
+/// All annotations, keyed by `owner/name`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AnnotationStore {
+    #[serde(flatten)]
+    pub skills: HashMap<String, Vec<Annotation>>,
+}
+
+/// Path to the annotations file.
+fn annotations_path() -> PathBuf {
+    config::config_dir().join("annotations.json")
+}
+
+/// Load annotations from disk. Returns empty store if file doesn't exist.
+pub fn load() -> AnnotationStore {
+    let path = annotations_path();
+    if !path.is_file() {
+        return AnnotationStore::default();
+    }
+    match std::fs::read_to_string(&path) {
+        Ok(data) => serde_json::from_str(&data).unwrap_or_default(),
+        Err(_) => AnnotationStore::default(),
+    }
+}
+
+/// Save annotations to disk.
+pub fn save(store: &AnnotationStore) -> crate::error::Result<()> {
+    let path = annotations_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let data = serde_json::to_string_pretty(store)
+        .map_err(|e| crate::error::Error::Other(e.to_string()))?;
+    std::fs::write(&path, data)?;
+    Ok(())
+}
+
+/// Add an annotation to a skill.
+pub fn annotate(owner: &str, name: &str, note: &str) -> crate::error::Result<usize> {
+    let mut store = load();
+    let key = format!("{owner}/{name}");
+    let entry = store.skills.entry(key).or_default();
+    entry.push(Annotation {
+        note: note.to_string(),
+        created_at: config::now_iso8601(),
+    });
+    let count = entry.len();
+    save(&store)?;
+    Ok(count)
+}
+
+/// Get annotations for a skill.
+pub fn get(owner: &str, name: &str) -> Vec<Annotation> {
+    let store = load();
+    let key = format!("{owner}/{name}");
+    store.skills.get(&key).cloned().unwrap_or_default()
+}
+
+/// List all annotated skills with their annotation counts.
+pub fn list_all() -> Vec<(String, usize)> {
+    let store = load();
+    let mut result: Vec<(String, usize)> = store
+        .skills
+        .iter()
+        .map(|(k, v)| (k.clone(), v.len()))
+        .collect();
+    result.sort_by(|a, b| a.0.cmp(&b.0));
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn annotation_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Override HOME for isolated config dir
+        let prev = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+
+        let count = annotate("acme", "rust-dev", "Missing async pool docs").unwrap();
+        assert_eq!(count, 1);
+
+        let count = annotate("acme", "rust-dev", "Could use error handling section").unwrap();
+        assert_eq!(count, 2);
+
+        let notes = get("acme", "rust-dev");
+        assert_eq!(notes.len(), 2);
+        assert_eq!(notes[0].note, "Missing async pool docs");
+        assert_eq!(notes[1].note, "Could use error handling section");
+        assert!(!notes[0].created_at.is_empty());
+
+        let all = list_all();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0], ("acme/rust-dev".to_string(), 2));
+
+        // Empty skill
+        let empty = get("nobody", "nothing");
+        assert!(empty.is_empty());
+
+        if let Some(h) = prev {
+            unsafe { std::env::set_var("HOME", h) };
+        }
+    }
+}

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -1,0 +1,110 @@
+//! Discover skill repos via GitHub code search.
+//!
+//! Searches GitHub for repos containing `skillet.toml` files,
+//! indicating they've opted into the skillet ecosystem.
+
+use std::process::Command;
+
+use serde::Deserialize;
+
+/// A discovered skill repo from GitHub search.
+#[derive(Debug, Clone)]
+pub struct DiscoveredRepo {
+    /// Full repo name (e.g. "owner/repo")
+    pub full_name: String,
+    /// Repo description
+    pub description: String,
+    /// Clone URL
+    pub clone_url: String,
+}
+
+/// Search result from GitHub code search API.
+#[derive(Debug, Deserialize)]
+struct SearchResult {
+    items: Vec<SearchItem>,
+    total_count: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchItem {
+    repository: RepoInfo,
+}
+
+#[derive(Debug, Deserialize)]
+struct RepoInfo {
+    full_name: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    private: bool,
+}
+
+/// Search GitHub for repos containing `skillet.toml`.
+///
+/// Uses the `gh` CLI for authentication. Returns an error if `gh` is not
+/// installed or not authenticated.
+pub fn search_github(query: Option<&str>) -> crate::error::Result<Vec<DiscoveredRepo>> {
+    let search_query = if let Some(q) = query {
+        format!("filename:skillet.toml {q}")
+    } else {
+        "filename:skillet.toml".to_string()
+    };
+
+    let output = Command::new("gh")
+        .args([
+            "api",
+            "search/code",
+            "-X",
+            "GET",
+            "-f",
+            &format!("q={search_query}"),
+            "-f",
+            "per_page=30",
+        ])
+        .output()
+        .map_err(|e| crate::error::Error::Io {
+            context: "failed to run gh CLI (is it installed?)".to_string(),
+            source: e,
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(crate::error::Error::Other(format!(
+            "GitHub search failed: {stderr}"
+        )));
+    }
+
+    let result: SearchResult = serde_json::from_slice(&output.stdout)
+        .map_err(|e| crate::error::Error::Other(format!("Failed to parse search results: {e}")))?;
+
+    // Deduplicate by repo and skip private repos
+    let mut seen = std::collections::HashSet::new();
+    let repos: Vec<DiscoveredRepo> = result
+        .items
+        .into_iter()
+        .filter_map(|item| {
+            if item.repository.private {
+                return None;
+            }
+            let name = item.repository.full_name.clone();
+            if seen.insert(name) {
+                let clone_url = format!("https://github.com/{}.git", item.repository.full_name);
+                Some(DiscoveredRepo {
+                    full_name: item.repository.full_name,
+                    description: item.repository.description.unwrap_or_default(),
+                    clone_url,
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    tracing::info!(
+        total = result.total_count,
+        returned = repos.len(),
+        "GitHub search for skillet.toml"
+    );
+
+    Ok(repos)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,11 @@
 //! and serving skills from repos as MCP prompts. The binary crate
 //! adds the CLI (clap) and MCP server (tower-mcp) on top.
 
+pub mod annotations;
 pub mod bm25;
 pub mod cache;
 pub mod config;
+pub mod discover;
 pub mod error;
 pub mod git;
 pub mod index;

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,14 @@ enum Command {
     Info(InfoArgs),
     /// Manage configured repos
     Repo(RepoCommand),
+    /// Discover skill repos on GitHub
+    Discover(DiscoverArgs),
+}
+
+#[derive(clap::Args, Debug)]
+struct DiscoverArgs {
+    /// Optional search query to narrow results
+    query: Option<String>,
 }
 
 #[derive(clap::Args, Debug, Clone)]
@@ -231,6 +239,7 @@ async fn main() -> ExitCode {
         Some(Command::Categories(args)) => cli::search::run_categories(args),
         Some(Command::Info(args)) => cli::search::run_info(args),
         Some(Command::Repo(args)) => cli::repo::run_repo(args),
+        Some(Command::Discover(args)) => run_discover(args),
         Some(Command::Serve(args)) => run_serve(args).await,
         None if interactive_tty => {
             eprintln!("Skillet - skill discovery for AI agents\n");
@@ -248,7 +257,7 @@ async fn main() -> ExitCode {
 }
 
 /// All known tool short names.
-const ALL_TOOL_NAMES: &[&str] = &["search", "categories", "owner", "info"];
+const ALL_TOOL_NAMES: &[&str] = &["search", "categories", "owner", "info", "annotate"];
 
 /// Resolved set of capabilities to expose from the MCP server.
 struct ServerCapabilities {
@@ -297,6 +306,9 @@ fn build_router(
     if caps.tools.contains("info") {
         router = router.tool(tools::info_skill::build(state.clone()));
     }
+    if caps.tools.contains("annotate") {
+        router = router.tool(tools::annotate_skill::build());
+    }
 
     // Build dynamic instructions based on exposed capabilities
     router = router.instructions(build_instructions(caps));
@@ -330,6 +342,11 @@ fn build_instructions(caps: &ServerCapabilities) -> String {
             "- info_skill: Get detailed information about a specific skill (version, author, tags, files, etc.)",
         );
     }
+    if caps.tools.contains("annotate") {
+        tool_lines.push(
+            "- annotate_skill: Attach a persistent note to a skill (records gaps, tips, corrections)",
+        );
+    }
     if !tool_lines.is_empty() {
         text.push_str("Tools:\n");
         for line in &tool_lines {
@@ -347,6 +364,40 @@ fn build_instructions(caps: &ServerCapabilities) -> String {
     );
 
     text
+}
+
+/// Run the `discover` subcommand.
+fn run_discover(args: DiscoverArgs) -> ExitCode {
+    let repos = match skillet_mcp::discover::search_github(args.query.as_deref()) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            eprintln!("\nMake sure `gh` CLI is installed and authenticated.");
+            return ExitCode::from(1);
+        }
+    };
+
+    if repos.is_empty() {
+        println!("No skill repos found on GitHub.");
+        return ExitCode::SUCCESS;
+    }
+
+    println!(
+        "Found {} repo{} with skillet.toml:\n",
+        repos.len(),
+        if repos.len() == 1 { "" } else { "s" }
+    );
+
+    for repo in &repos {
+        println!("  {}", repo.full_name);
+        if !repo.description.is_empty() {
+            println!("    {}", repo.description);
+        }
+        println!("    skillet repo add {}", repo.clone_url);
+        println!();
+    }
+
+    ExitCode::SUCCESS
 }
 
 /// Run the MCP server (default behavior / `serve` subcommand).

--- a/src/tools/annotate_skill.rs
+++ b/src/tools/annotate_skill.rs
@@ -1,0 +1,36 @@
+//! annotate_skill tool -- attach persistent notes to skills
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{CallToolResult, Tool, ToolBuilder};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AnnotateSkillInput {
+    /// Skill owner (e.g. "redis")
+    owner: String,
+    /// Skill name (e.g. "redis-development")
+    name: String,
+    /// Note to attach to the skill
+    note: String,
+}
+
+pub fn build() -> Tool {
+    ToolBuilder::new("annotate_skill")
+        .description(
+            "Attach a persistent note to a skill. Notes survive across sessions \
+             and are shown in skill info. Use this to record gaps, tips, or \
+             corrections discovered during skill use.",
+        )
+        .handler(|input: AnnotateSkillInput| async move {
+            match skillet_mcp::annotations::annotate(&input.owner, &input.name, &input.note) {
+                Ok(count) => Ok(CallToolResult::text(format!(
+                    "Annotated {}/{}. Total annotations: {count}",
+                    input.owner, input.name
+                ))),
+                Err(e) => Ok(CallToolResult::error(format!(
+                    "Failed to save annotation: {e}"
+                ))),
+            }
+        })
+        .build()
+}

--- a/src/tools/info_skill.rs
+++ b/src/tools/info_skill.rs
@@ -146,6 +146,15 @@ pub fn build(state: Arc<AppState>) -> Tool {
                 // Prompt name for agent use
                 output.push_str(&format!("\n**Prompt:** `{}_{}`\n", input.owner, input.name));
 
+                // Annotations
+                let annotations = skillet_mcp::annotations::get(&input.owner, &input.name);
+                if !annotations.is_empty() {
+                    output.push_str(&format!("\n**Annotations ({}):**\n", annotations.len()));
+                    for ann in &annotations {
+                        output.push_str(&format!("- {} ({})\n", ann.note, ann.created_at));
+                    }
+                }
+
                 Ok(CallToolResult::text(output))
             },
         )

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,3 +1,4 @@
+pub mod annotate_skill;
 pub mod info_skill;
 pub mod list_categories;
 pub mod list_skills_by_owner;


### PR DESCRIPTION
## Summary

Two new features that close the main competitive gaps with context-hub.

### Skill Annotations (#205)

Agents can attach persistent notes to skills that survive across sessions.

```
annotate_skill(owner: "redis", name: "redis-development", 
               note: "Connection pooling section doesn't cover async pools")
```

- Stored in `~/.config/skillet/annotations.json`
- Displayed in `info_skill` output
- New MCP tool: `annotate_skill`

### GitHub Repo Discovery (#185)

Find skill repos on GitHub by searching for `skillet.toml`.

```
$ skillet discover
Found 2 repos with skillet.toml:

  joshrotenberg/skillet
    MCP-native skill discovery for AI agents.
    skillet repo add https://github.com/joshrotenberg/skillet.git
```

- Uses `gh` CLI for authentication
- Optional query parameter to narrow results
- Shows `skillet repo add` command for easy onboarding

## Test plan

- [x] 246 tests passing
- [x] `cargo fmt`, `cargo clippy` clean
- [x] Annotation roundtrip unit test
- [x] Discover CLI tested manually against GitHub API

Closes #205, #185