### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0] - 2026-03-28
+
+### Bug Fixes
+
+- Parse YAML frontmatter properly (multiline scalars, nested metadata) ([#216](https://github.com/joshrotenberg/skillet/pull/216))
+
+### Documentation
+
+- Update README to reflect frontmatter-primary model and expanded repos ([#223](https://github.com/joshrotenberg/skillet/pull/223))
+
+### Features
+
+- Expand default suggest repos for day-1 coverage ([#219](https://github.com/joshrotenberg/skillet/pull/219))
+
+### Refactor
+
+- Make SKILL.md frontmatter the primary metadata source (#215 phase 2) ([#218](https://github.com/joshrotenberg/skillet/pull/218))
+
+### Testing
+
+- Add coverage for frontmatter-primary metadata parsing ([#221](https://github.com/joshrotenberg/skillet/pull/221))
+- Add integration coverage for MCP tools, auto-detect, and suggest limits ([#222](https://github.com/joshrotenberg/skillet/pull/222))
+
+
+
 ## [0.5.1] - 2026-03-18
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "skillet-mcp"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillet-mcp"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.90"
 description = "MCP-native skill discovery for AI agents"


### PR DESCRIPTION



## 🤖 New release

* `skillet-mcp`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `skillet-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Frontmatter.trigger in /tmp/.tmpG21JmB/skillet/src/project.rs:255
  field Frontmatter.categories in /tmp/.tmpG21JmB/skillet/src/project.rs:257
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0] - 2026-03-28

### Bug Fixes

- Parse YAML frontmatter properly (multiline scalars, nested metadata) ([#216](https://github.com/joshrotenberg/skillet/pull/216))

### Documentation

- Update README to reflect frontmatter-primary model and expanded repos ([#223](https://github.com/joshrotenberg/skillet/pull/223))

### Features

- Expand default suggest repos for day-1 coverage ([#219](https://github.com/joshrotenberg/skillet/pull/219))

### Refactor

- Make SKILL.md frontmatter the primary metadata source (#215 phase 2) ([#218](https://github.com/joshrotenberg/skillet/pull/218))

### Testing

- Add coverage for frontmatter-primary metadata parsing ([#221](https://github.com/joshrotenberg/skillet/pull/221))
- Add integration coverage for MCP tools, auto-detect, and suggest limits ([#222](https://github.com/joshrotenberg/skillet/pull/222))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).